### PR TITLE
Added route protection for Admin route

### DIFF
--- a/client/Routes.js
+++ b/client/Routes.js
@@ -4,6 +4,9 @@ import Login from './components/core/Login';
 import NavBar from './components/core/NavBar';
 import AdminDashboard from './components/user/AdminDashboard';
 import Footer from './components/core/Footer'
+import AdminRoute from './components/AdminRoute';
+
+
 
 const Routes = () => {
   return (
@@ -11,7 +14,8 @@ const Routes = () => {
       <NavBar />
       <Switch>
         <Route path='/' exact component={Login} />
-        <Route path='/orgAdmin' exact component={AdminDashboard} />
+        <AdminRoute path='/orgAdmin' component={AdminDashboard} />
+        {/* <Route path='/orgAdmin' exact component={AdminDashboard} /> */}
       </Switch>
       <Footer />
     </BrowserRouter>

--- a/client/Routes.js
+++ b/client/Routes.js
@@ -15,7 +15,6 @@ const Routes = () => {
       <Switch>
         <Route path='/' exact component={Login} />
         <AdminRoute path='/orgAdmin' component={AdminDashboard} />
-        {/* <Route path='/orgAdmin' exact component={AdminDashboard} /> */}
       </Switch>
       <Footer />
     </BrowserRouter>

--- a/client/components/AdminRoute.js
+++ b/client/components/AdminRoute.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
+import AdminDashboard from './user/AdminDashboard';
+import {signin} from './auth/';
+
+
+
+const AdminRoute = ({component : Component, ...rest}) => {
+    return (
+    <Route {...rest} render={(props) => (
+    signin.isAdmin === true ? 
+    <Component {...props}/>
+    : <Redirect to='/'/> )} />
+    )
+}
+   
+    
+
+export default AdminRoute;

--- a/client/components/auth/index.js
+++ b/client/components/auth/index.js
@@ -1,12 +1,14 @@
 import { Link, Redirect } from 'react-router-dom';
 import React, { useState } from 'react';
 
-export const signin = (user) => {
-  console.log(user)
-  if (user.email === 'admin') {
-    console.log(user)
-    return true
-  } else {
-    return false
+
+export const signin = {
+  isAdmin : false, 
+  checkIfAdmin(user) {
+    if (user.email === 'admin') {
+      console.log(user)
+      this.isAdmin = true;
+    } 
   }
 }
+

--- a/client/components/core/Login.js
+++ b/client/components/core/Login.js
@@ -28,10 +28,12 @@ const Login = () => {
   const clickSubmit = (event) => {
     event.preventDefault()
     setValues({ ...values, error: false })
-    if (signin({ email, password }) === true) {
+    signin.checkIfAdmin({ email, password });
+    if (signin.isAdmin === true) {
       setValues({ ...values, redirect: true })
     }
   }
+
 
   const redirectUser = () => {
     if (redirect === true) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3518,7 +3518,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3539,12 +3540,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3559,17 +3562,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3686,7 +3692,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3698,6 +3705,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3712,6 +3720,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3719,12 +3728,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3743,6 +3754,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3804,7 +3816,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3832,7 +3845,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3844,6 +3858,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3921,7 +3936,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3957,6 +3973,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3976,6 +3993,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4019,12 +4037,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3518,8 +3518,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3540,14 +3539,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3562,20 +3559,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3692,8 +3686,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3705,7 +3698,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3720,7 +3712,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3728,14 +3719,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3754,7 +3743,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3816,8 +3804,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3845,8 +3832,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3858,7 +3844,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3936,8 +3921,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3973,7 +3957,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3993,7 +3976,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4037,14 +4019,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
When user logs in as Admin it redirects to '/orgAdmin' route, if user tries to go to '/orgAdmin' without entering Admin into email field then they are redirected to '/' route