### PR TITLE
Firestore rules

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,29 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  main:
+    name: Build, Deploy to Test Infrastructure, and Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        working-directory: cloud-functions/functions
+        run: npm install
+      - name: Build and Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --project=test
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          PROJECT_PATH: cloud-functions/
+      - name: Run Tests
+        working-directory: cloud-functions/functions
+        run: npm run test_ci
+        env:
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,3 +27,4 @@ jobs:
         run: npm run test_ci
         env:
           FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/cloud-functions/README.md
+++ b/cloud-functions/README.md
@@ -15,6 +15,7 @@ Unfortunately the Firebase emulators don't support many auth features, so becaus
 
 ```
 firebase deploy --only functions --project=dev
+firebase deploy --only firestore:rules --project=dev
 ```
 
 Once functions are deployed, the dev infrastructure can loaded with some fake sample data by navigating to the `functions/` directory and running:
@@ -35,6 +36,7 @@ This means that in order for tests to run properly, they must be deployed first 
 
 ```
 firebase deploy --only functions --project=test
+firebase deploy --only firestore:rules --project=test
 ```
 
 Once changes are deployed, tests can be run from the `functions/` directory. Tests require a firebase admin key to run properly, stored as `functions/permission-portal-test-firebase-admin-key.json` (ask maintainer). Because they are written in Typescript, they must be built first:

--- a/cloud-functions/firebase.json
+++ b/cloud-functions/firebase.json
@@ -1,8 +1,8 @@
 {
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "functions": {
-    "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" run lint",
-      "npm --prefix \"$RESOURCE_DIR\" run build"
-    ]
+    "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run lint", "npm --prefix \"$RESOURCE_DIR\" run build"]
   }
 }

--- a/cloud-functions/firestore.rules
+++ b/cloud-functions/firestore.rules
@@ -11,7 +11,7 @@ service cloud.firestore {
     }
 
     function isAdmin() {
-      return request.auth.isAdmin == true;
+      return request.auth.token.isAdmin == true;
     }
 
     function isInOrganization(organizationID) {

--- a/cloud-functions/firestore.rules
+++ b/cloud-functions/firestore.rules
@@ -1,0 +1,24 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+		// Disallow all reads and writes by default
+    match /{document=**} {
+      allow read, write: if false
+    }
+    
+   	function isSignedIn() {
+    	return request.auth != null
+    }
+    
+    function isSelfOrAdminInOrg(email, orgID) {
+    	let isSelf = request.auth.token.email == email;
+      let isAdmin = request.auth.token.isAdmin;
+      let isInOrg = request.auth.token.organizationID == orgID;
+      return isSelf || (isAdmin && isInOrg);
+    }
+
+    match /users/{email} {
+    	allow read, write: if isSignedIn() && isSelfOrAdminInOrg(email, resource.data.orgID);
+    }
+  }
+}

--- a/cloud-functions/firestore.rules
+++ b/cloud-functions/firestore.rules
@@ -3,22 +3,33 @@ service cloud.firestore {
   match /databases/{database}/documents {
 		// Disallow all reads and writes by default
     match /{document=**} {
-      allow read, write: if false
+      allow read, write: if false;
     }
     
    	function isSignedIn() {
-    	return request.auth != null
+    	return request.auth != null;
+    }
+
+    function isAdmin() {
+      return request.auth.isAdmin == true;
+    }
+
+    function isInOrganization(organizationID) {
+      return request.auth.token.organizationID == organizationID;
     }
     
-    function isSelfOrAdminInOrg(email, orgID) {
+    function isSelfOrAdminInOrg(email, organizationID) {
     	let isSelf = request.auth.token.email == email;
-      let isAdmin = request.auth.token.isAdmin;
-      let isInOrg = request.auth.token.organizationID == orgID;
-      return isSelf || (isAdmin && isInOrg);
+      return isSelf || (isAdmin() && isInOrganization(organizationID));
     }
 
     match /users/{email} {
-    	allow read, write: if isSignedIn() && isSelfOrAdminInOrg(email, resource.data.orgID);
+    	allow read, write: if isSignedIn() && isSelfOrAdminInOrg(email, resource.data.organizationID);
+    }
+
+    match /organizations/{organizationID} {
+      allow read: if isSignedIn() && isInOrganization(organizationID);
+      allow write: if isSignedIn() && isAdmin() && isInOrganization(organizationID);
     }
   }
 }

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -35,8 +35,15 @@ firebase.initializeApp(firebaseConfig);
 
 // Initialize admin SDK
 const serviceAccount =
-  process.env.NODE_ENV === 'development'
-    ? require('../../permission-portal-dev-firebase-admin-key.json')
+  process.env.NODE_ENV === 'ci'
+    ? {
+        projectId: 'permission-portal-test',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\n' +
+          process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, '\n') +
+          '\n-----END PRIVATE KEY-----\n',
+        clientEmail: 'firebase-adminsdk-nqxd8@permission-portal-test.iam.gserviceaccount.com',
+      }
     : require('../../permission-portal-test-firebase-admin-key.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -11,26 +11,15 @@ import 'firebase/firestore';
 jest.setTimeout(60000);
 
 // Initialize client SDK
-const firebaseConfig =
-  process.env.NODE_ENV === 'development'
-    ? {
-        apiKey: 'AIzaSyAKbS8JEe1UVSZdaJfN4RnsRFPE7Tb-YpM',
-        authDomain: 'permission-portal-dev.firebaseapp.com',
-        databaseURL: 'https://permission-portal-dev.firebaseio.com',
-        projectId: 'permission-portal-dev',
-        storageBucket: 'permission-portal-dev.appspot.com',
-        messagingSenderId: '885750041965',
-        appId: '1:885750041965:web:14133265537c686c1dde64',
-      }
-    : {
-        apiKey: 'AIzaSyAHVZXO-wFnGmUIBLxF6-mY3tuleK4ENVo',
-        authDomain: 'permission-portal-test.firebaseapp.com',
-        databaseURL: 'https://permission-portal-test.firebaseio.com',
-        projectId: 'permission-portal-test',
-        storageBucket: 'permission-portal-test.appspot.com',
-        messagingSenderId: '1090782248577',
-        appId: '1:1090782248577:web:184d481f492cfa4edc1780',
-      };
+const firebaseConfig = {
+  apiKey: 'AIzaSyAHVZXO-wFnGmUIBLxF6-mY3tuleK4ENVo',
+  authDomain: 'permission-portal-test.firebaseapp.com',
+  databaseURL: 'https://permission-portal-test.firebaseio.com',
+  projectId: 'permission-portal-test',
+  storageBucket: 'permission-portal-test.appspot.com',
+  messagingSenderId: '1090782248577',
+  appId: '1:1090782248577:web:184d481f492cfa4edc1780',
+};
 firebase.initializeApp(firebaseConfig);
 
 // Initialize admin SDK

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -47,10 +47,7 @@ const serviceAccount =
     : require('../../permission-portal-test-firebase-admin-key.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL:
-    process.env.NODE_ENV === 'development'
-      ? 'https://permission-portal-dev.firebaseio.com'
-      : 'https://permission-portal-test.firebaseio.com',
+  databaseURL: 'https://permission-portal-test.firebaseio.com',
 });
 
 // Initialize commonly used vars

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -490,7 +490,7 @@ test("Manually added user in users table with empty string organizationID can't 
           })
           .then(() => {
             // delay to allow onCreate to trigger and realize users table document is faulty
-            return delay(DELAY).then(() => {
+            return delay(DELAY * 2).then(() => {
               // check that user has been deleted from Firebase Auth
               return adminAuth
                 .getUserByEmail('testuser@goodcorp.com')

--- a/cloud-functions/functions/__tests__/rules.test.ts
+++ b/cloud-functions/functions/__tests__/rules.test.ts
@@ -63,17 +63,19 @@ const adminAuth = admin.auth();
 // to give the trigger time to run.
 // const DELAY = 10000;
 
-// Track created user's ids for easy deletion afterAll()
+// Track important variables for use in tests and easy deletion in afterAll()
 let soylentGreenAdminID: string;
 let soylentGreenRegularUserId: string;
 let initechAdminID: string;
 let initechRegularUserId: string;
+let soylentGreenID: string;
+let initechID: string;
 
 beforeAll(() => {
   const soylentGreenRef = adminDb.collection('organizations').doc();
   const initechRef = adminDb.collection('organizations').doc();
-  const soylentGreenID = soylentGreenRef.id;
-  const initechID = initechRef.id;
+  soylentGreenID = soylentGreenRef.id;
+  initechID = initechRef.id;
 
   return soylentGreenRef
     .set({
@@ -237,16 +239,62 @@ afterAll(() => {
     });
 });
 
-test("Unauthenticated user can't touch users", () => {
+test("Unauthenticated user can't read users", () => {
   return clientDb
     .collection('users')
     .doc('admin@soylentgreen.com')
     .get()
     .then(() => {
-      throw new Error('Unauthenticated user should not be able to read from users table');
+      throw new Error('Unauthenticated user should not be able to read from users collection');
     })
     .catch(err => {
       expect(err.code).toEqual('permission-denied');
       expect(err.message).toEqual('Missing or insufficient permissions.');
+    });
+});
+
+test("Unauthenticated user can't write users", () => {
+  return clientDb
+    .collection('users')
+    .doc('some doc in users')
+    .set({
+      someField: 'someValue'
+    })
+    .then(() => {
+      throw new Error('Unauthenticated user should not be able to write to users collection');
+    })
+    .catch(err => {
+      expect(err.code).toEqual('permission-denied');
+      expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+    });
+});
+
+test("Unauthenticated user can't read organizations", () => {
+  return clientDb
+    .collection('organizations')
+    .doc(soylentGreenID)
+    .get()
+    .then(() => {
+      throw new Error('Unauthenticated user should not be able to read from organizations table');
+    })
+    .catch(err => {
+      expect(err.code).toEqual('permission-denied');
+      expect(err.message).toEqual('Missing or insufficient permissions.');
+    });
+});
+
+test("Unauthenticated user can't write organizations", () => {
+  return clientDb
+    .collection('organizations')
+    .doc('some doc in organizations')
+    .set({
+      someField: 'someValue'
+    })
+    .then(() => {
+      throw new Error('Unauthenticated user should not be able to write to organizations table');
+    })
+    .catch(err => {
+      expect(err.code).toEqual('permission-denied');
+      expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
     });
 });

--- a/cloud-functions/functions/__tests__/rules.test.ts
+++ b/cloud-functions/functions/__tests__/rules.test.ts
@@ -51,17 +51,17 @@ admin.initializeApp({
 // Initialize commonly used vars
 const clientDb = firebase.firestore();
 const adminDb = admin.firestore();
-// const clientAuth = firebase.auth();
+const clientAuth = firebase.auth();
 const adminAuth = admin.auth();
 // const clientFunctions = firebase.functions();
 // const createUser = clientFunctions.httpsCallable('createUser');
 
 // Delay function to deal with Cloud Functions triggers needing time to propagate.
-// const delay = (t: number) => new Promise(resolve => setTimeout(resolve, t));
+const delay = (t: number) => new Promise(resolve => setTimeout(resolve, t));
 // Milliseconds to delay at certain points in the test suite. Incredibly annoying, but because
 // our system relies on the onCreate trigger for various features, we need to provide delays in the tests in order
 // to give the trigger time to run.
-// const DELAY = 10000;
+const DELAY = 3000;
 
 // Track important variables for use in tests and easy deletion in afterAll()
 let soylentGreenAdminID: string;
@@ -102,73 +102,82 @@ beforeAll(() => {
               console.log(
                 `Successfully created Soylent Green admin user with username/password admin@soylentgreen.com`
               );
-              return adminDb
-                .collection('users')
-                .doc('user@soylentgreen.com')
-                .set({
-                  isSuperAdmin: false,
-                  isAdmin: false,
-                  organizationID: soylentGreenID
-                })
-                .then(() => {
-                  return adminAuth
-                    .createUser({
-                      email: 'user@soylentgreen.com',
-                      password: 'user@soylentgreen.com'
-                    })
-                    .then(soylentGreenRegularUserRecord => {
-                      soylentGreenRegularUserId = soylentGreenRegularUserRecord.uid;
-                      console.log(
-                        `Successfully created Soylent Green regular user with username/password user@soylentgreen.com`
-                      );
-                      return initechRef
-                        .set({
-                          name: 'Initech'
-                        })
-                        .then(() => {
-                          console.log(`Successfully created organization Initech with document ID ${initechID}`);
-                          return adminDb
-                            .collection('users')
-                            .doc('admin@initech.com')
+              return delay(DELAY).then(() => {
+                return adminDb
+                  .collection('users')
+                  .doc('user@soylentgreen.com')
+                  .set({
+                    isSuperAdmin: false,
+                    isAdmin: false,
+                    organizationID: soylentGreenID
+                  })
+                  .then(() => {
+                    return adminAuth
+                      .createUser({
+                        email: 'user@soylentgreen.com',
+                        password: 'user@soylentgreen.com'
+                      })
+                      .then(soylentGreenRegularUserRecord => {
+                        soylentGreenRegularUserId = soylentGreenRegularUserRecord.uid;
+                        console.log(
+                          `Successfully created Soylent Green regular user with username/password user@soylentgreen.com`
+                        );
+                        return delay(DELAY).then(() => {
+                          return initechRef
                             .set({
-                              isSuperAdmin: false,
-                              isAdmin: true,
-                              organizationID: initechID
+                              name: 'Initech'
                             })
                             .then(() => {
-                              return adminAuth
-                                .createUser({
-                                  email: 'admin@initech.com',
-                                  password: 'admin@initech.com'
+                              console.log(`Successfully created organization Initech with document ID ${initechID}`);
+                              return adminDb
+                                .collection('users')
+                                .doc('admin@initech.com')
+                                .set({
+                                  isSuperAdmin: false,
+                                  isAdmin: true,
+                                  organizationID: initechID
                                 })
-                                .then(initechAdminUserRecord => {
-                                  initechAdminID = initechAdminUserRecord.uid;
-                                  console.log(
-                                    `Successfully created Initech admin user with username/password admin@initech.com`
-                                  );
-                                  return adminDb
-                                    .collection('users')
-                                    .doc('user@initech.com')
-                                    .set({
-                                      isSuperAdmin: false,
-                                      isAdmin: false,
-                                      organizationID: initechID
+                                .then(() => {
+                                  return adminAuth
+                                    .createUser({
+                                      email: 'admin@initech.com',
+                                      password: 'admin@initech.com'
                                     })
-                                    .then(() => {
-                                      return adminAuth
-                                        .createUser({
-                                          email: 'user@initech.com',
-                                          password: 'user@initech.com'
-                                        })
-                                        .then(initechRegularUserRecord => {
-                                          initechRegularUserId = initechRegularUserRecord.uid;
-                                          console.log(
-                                            `Successfully created Initech regular user with username/password user@initech.com`
-                                          );
-                                        })
-                                        .catch(err => {
-                                          throw err;
-                                        });
+                                    .then(initechAdminUserRecord => {
+                                      initechAdminID = initechAdminUserRecord.uid;
+                                      console.log(
+                                        `Successfully created Initech admin user with username/password admin@initech.com`
+                                      );
+                                      return delay(DELAY).then(() => {
+                                        return adminDb
+                                          .collection('users')
+                                          .doc('user@initech.com')
+                                          .set({
+                                            isSuperAdmin: false,
+                                            isAdmin: false,
+                                            organizationID: initechID
+                                          })
+                                          .then(() => {
+                                            return adminAuth
+                                              .createUser({
+                                                email: 'user@initech.com',
+                                                password: 'user@initech.com'
+                                              })
+                                              .then(initechRegularUserRecord => {
+                                                initechRegularUserId = initechRegularUserRecord.uid;
+                                                console.log(
+                                                  `Successfully created Initech regular user with username/password user@initech.com`
+                                                );
+                                                return delay(DELAY);
+                                              })
+                                              .catch(err => {
+                                                throw err;
+                                              });
+                                          })
+                                          .catch(err => {
+                                            throw err;
+                                          });
+                                      });
                                     })
                                     .catch(err => {
                                       throw err;
@@ -181,18 +190,16 @@ beforeAll(() => {
                             .catch(err => {
                               throw err;
                             });
-                        })
-                        .catch(err => {
-                          throw err;
                         });
-                    })
-                    .catch(err => {
-                      throw err;
-                    });
-                })
-                .catch(err => {
-                  throw err;
-                });
+                      })
+                      .catch(err => {
+                        throw err;
+                      });
+                  })
+                  .catch(err => {
+                    throw err;
+                  });
+              });
             })
             .catch(err => {
               throw err;
@@ -297,4 +304,120 @@ test("Unauthenticated user can't write organizations", () => {
       expect(err.code).toEqual('permission-denied');
       expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
     });
+});
+
+test('Authenticated regular user can read his own data', () => {
+  return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+    return clientDb
+      .collection('users')
+      .doc('user@soylentgreen.com')
+      .get()
+      .then(userSnapshot => {
+        expect(userSnapshot.id).toEqual('user@soylentgreen.com');
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+});
+
+test("Authenticated regular user can't read other user's data", () => {
+  return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+    return clientDb
+      .collection('users')
+      .doc('admin@soylentgreen.com')
+      .get()
+      .then(() => {
+        throw new Error("Authenticated regular users should not be able to read other user's data");
+      })
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        expect(err.message).toEqual('Missing or insufficient permissions.');
+        return clientDb
+          .collection('users')
+          .doc('admin@initech.com')
+          .get()
+          .then(() => {
+            throw new Error("Authenticated regular users should not be able to read other user's data");
+          })
+          .catch(err2 => {
+            expect(err2.code).toEqual('permission-denied');
+            expect(err2.message).toEqual('Missing or insufficient permissions.');
+            return clientDb
+              .collection('users')
+              .doc('user@initech.com')
+              .get()
+              .then(() => {
+                throw new Error("Authenticated regular users should not be able to read other user's data");
+              })
+              .catch(err3 => {
+                expect(err3.code).toEqual('permission-denied');
+                expect(err3.message).toEqual('Missing or insufficient permissions.');
+              });
+          });
+      });
+  });
+});
+
+test('Authenticated admin user can read his own data', () => {
+  return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+    return clientDb
+      .collection('users')
+      .doc('admin@soylentgreen.com')
+      .get()
+      .then(userSnapshot => {
+        expect(userSnapshot.id).toEqual('admin@soylentgreen.com');
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+});
+
+test("Authenticated admin user can read other users' data if they're in his organization", () => {
+  return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+    return clientDb
+      .collection('users')
+      .doc('user@soylentgreen.com')
+      .get()
+      .then(userSnapshot => {
+        expect(userSnapshot.id).toEqual('user@soylentgreen.com');
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+});
+
+test("Authenticated admin user can't read other users' data if they're not in his organization", () => {
+  return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+    return clientDb
+      .collection('users')
+      .doc('admin@initech.com')
+      .get()
+      .then(userSnapshot => {
+        expect(userSnapshot.id).toEqual('user@soylentgreen.com');
+        throw new Error(
+          "Authenticated admin users should not be able to read other user's data if they're not in the same organization"
+        );
+      })
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        expect(err.message).toEqual('Missing or insufficient permissions.');
+        return clientDb
+          .collection('users')
+          .doc('user@initech.com')
+          .get()
+          .then(userSnapshot => {
+            expect(userSnapshot.id).toEqual('user@soylentgreen.com');
+            throw new Error(
+              "Authenticated admin users should not be able to read other user's data if they're not in the same organization"
+            );
+          })
+          .catch(err2 => {
+            expect(err2.code).toEqual('permission-denied');
+            expect(err2.message).toEqual('Missing or insufficient permissions.');
+          });
+      });
+  });
 });

--- a/cloud-functions/functions/__tests__/rules.test.ts
+++ b/cloud-functions/functions/__tests__/rules.test.ts
@@ -61,7 +61,7 @@ const delay = (t: number) => new Promise(resolve => setTimeout(resolve, t));
 // Milliseconds to delay at certain points in the test suite. Incredibly annoying, but because
 // our system relies on the onCreate trigger for various features, we need to provide delays in the tests in order
 // to give the trigger time to run.
-const DELAY = 3000;
+const DELAY = 10000;
 
 // Track important variables for use in tests and easy deletion in afterAll()
 let soylentGreenAdminID: string;

--- a/cloud-functions/functions/__tests__/rules.test.ts
+++ b/cloud-functions/functions/__tests__/rules.test.ts
@@ -37,8 +37,15 @@ firebase.initializeApp(firebaseConfig);
 
 // Initialize admin SDK
 const serviceAccount =
-  process.env.NODE_ENV === 'development'
-    ? require('../../permission-portal-dev-firebase-admin-key.json')
+  process.env.NODE_ENV === 'ci'
+    ? {
+        projectId: 'permission-portal-test',
+        privateKey:
+          '-----BEGIN PRIVATE KEY-----\n' +
+          process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, '\n') +
+          '\n-----END PRIVATE KEY-----\n',
+        clientEmail: 'firebase-adminsdk-nqxd8@permission-portal-test.iam.gserviceaccount.com'
+      }
     : require('../../permission-portal-test-firebase-admin-key.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),

--- a/cloud-functions/functions/__tests__/rules.test.ts
+++ b/cloud-functions/functions/__tests__/rules.test.ts
@@ -53,8 +53,6 @@ const clientDb = firebase.firestore();
 const adminDb = admin.firestore();
 const clientAuth = firebase.auth();
 const adminAuth = admin.auth();
-// const clientFunctions = firebase.functions();
-// const createUser = clientFunctions.httpsCallable('createUser');
 
 // Delay function to deal with Cloud Functions triggers needing time to propagate.
 const delay = (t: number) => new Promise(resolve => setTimeout(resolve, t));
@@ -246,178 +244,595 @@ afterAll(() => {
     });
 });
 
-test("Unauthenticated user can't read users", () => {
-  return clientDb
-    .collection('users')
-    .doc('admin@soylentgreen.com')
-    .get()
-    .then(() => {
-      throw new Error('Unauthenticated user should not be able to read from users collection');
-    })
-    .catch(err => {
-      expect(err.code).toEqual('permission-denied');
-      expect(err.message).toEqual('Missing or insufficient permissions.');
-    });
-});
-
-test("Unauthenticated user can't write users", () => {
-  return clientDb
-    .collection('users')
-    .doc('some doc in users')
-    .set({
-      someField: 'someValue'
-    })
-    .then(() => {
-      throw new Error('Unauthenticated user should not be able to write to users collection');
-    })
-    .catch(err => {
-      expect(err.code).toEqual('permission-denied');
-      expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
-    });
-});
-
-test("Unauthenticated user can't read organizations", () => {
-  return clientDb
-    .collection('organizations')
-    .doc(soylentGreenID)
-    .get()
-    .then(() => {
-      throw new Error('Unauthenticated user should not be able to read from organizations table');
-    })
-    .catch(err => {
-      expect(err.code).toEqual('permission-denied');
-      expect(err.message).toEqual('Missing or insufficient permissions.');
-    });
-});
-
-test("Unauthenticated user can't write organizations", () => {
-  return clientDb
-    .collection('organizations')
-    .doc('some doc in organizations')
-    .set({
-      someField: 'someValue'
-    })
-    .then(() => {
-      throw new Error('Unauthenticated user should not be able to write to organizations table');
-    })
-    .catch(err => {
-      expect(err.code).toEqual('permission-denied');
-      expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
-    });
-});
-
-test('Authenticated regular user can read his own data', () => {
-  return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
-    return clientDb
-      .collection('users')
-      .doc('user@soylentgreen.com')
-      .get()
-      .then(userSnapshot => {
-        expect(userSnapshot.id).toEqual('user@soylentgreen.com');
-      })
-      .catch(err => {
-        throw err;
-      });
-  });
-});
-
-test("Authenticated regular user can't read other user's data", () => {
-  return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+describe("Unauthenticated users can't do anything", () => {
+  test("Unauthenticated user can't read users", () => {
     return clientDb
       .collection('users')
       .doc('admin@soylentgreen.com')
       .get()
       .then(() => {
-        throw new Error("Authenticated regular users should not be able to read other user's data");
+        throw new Error('Unauthenticated user should not be able to read from users collection');
       })
       .catch(err => {
         expect(err.code).toEqual('permission-denied');
         expect(err.message).toEqual('Missing or insufficient permissions.');
+      });
+  });
+
+  test("Unauthenticated user can't write users", () => {
+    return clientDb
+      .collection('users')
+      .doc('some doc in users')
+      .update({
+        someField: 'someValue'
+      })
+      .then(() => {
+        throw new Error('Unauthenticated user should not be able to write to users collection');
+      })
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+      });
+  });
+
+  test("Unauthenticated user can't read organizations", () => {
+    return clientDb
+      .collection('organizations')
+      .doc(soylentGreenID)
+      .get()
+      .then(() => {
+        throw new Error('Unauthenticated user should not be able to read from organizations table');
+      })
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        expect(err.message).toEqual('Missing or insufficient permissions.');
+      });
+  });
+
+  test("Unauthenticated user can't write organizations", () => {
+    return clientDb
+      .collection('organizations')
+      .doc('some doc in organizations')
+      .update({
+        someField: 'someValue'
+      })
+      .then(() => {
+        throw new Error('Unauthenticated user should not be able to write to organizations table');
+      })
+      .catch(err => {
+        expect(err.code).toEqual('permission-denied');
+        expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+      });
+  });
+});
+
+describe('Test proper read/write permissions for regular users (non-admins)', () => {
+  test('Authenticated regular user can read his own data', () => {
+    return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('user@soylentgreen.com')
+        .get()
+        .then(userSnapshot => {
+          expect(userSnapshot.id).toEqual('user@soylentgreen.com');
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+  });
+
+  test('Authenticated regular user can write his own data', () => {
+    return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('user@soylentgreen.com')
+        .update({
+          newField: 'newValue'
+        })
+        .then(() => {
+          return clientDb
+            .collection('users')
+            .doc('user@soylentgreen.com')
+            .get()
+            .then(userSnapshot => userSnapshot.data())
+            .then(user => {
+              expect(user).toBeDefined();
+              expect(user!.newField).toEqual('newValue');
+            });
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+  });
+
+  test("Authenticated regular user can't read other user's data", () => {
+    return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('admin@soylentgreen.com')
+        .get()
+        .then(() => {
+          throw new Error("Authenticated regular users should not be able to read other user's data");
+        })
+        .catch(err => {
+          expect(err.code).toEqual('permission-denied');
+          expect(err.message).toEqual('Missing or insufficient permissions.');
+          return clientDb
+            .collection('users')
+            .doc('admin@initech.com')
+            .get()
+            .then(() => {
+              throw new Error("Authenticated regular users should not be able to read other user's data");
+            })
+            .catch(err2 => {
+              expect(err2.code).toEqual('permission-denied');
+              expect(err2.message).toEqual('Missing or insufficient permissions.');
+              return clientDb
+                .collection('users')
+                .doc('user@initech.com')
+                .get()
+                .then(() => {
+                  throw new Error("Authenticated regular users should not be able to read other user's data");
+                })
+                .catch(err3 => {
+                  expect(err3.code).toEqual('permission-denied');
+                  expect(err3.message).toEqual('Missing or insufficient permissions.');
+                });
+            });
+        });
+    });
+  });
+
+  test("Authenticated regular user can't write other user's data", () => {
+    return clientAuth.signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('admin@soylentgreen.com')
+        .update({
+          newField: 'newValue'
+        })
+        .then(() => {
+          throw new Error("Authenticated regular users should not be able to write other user's data");
+        })
+        .catch(err => {
+          expect(err.code).toEqual('permission-denied');
+          expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+          return clientDb
+            .collection('users')
+            .doc('admin@initech.com')
+            .update({
+              newField: 'newValue'
+            })
+            .then(() => {
+              throw new Error("Authenticated regular users should not be able to read other user's data");
+            })
+            .catch(err2 => {
+              expect(err2.code).toEqual('permission-denied');
+              expect(err2.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+              return clientDb
+                .collection('users')
+                .doc('user@initech.com')
+                .update({
+                  newField: 'newValue'
+                })
+                .then(() => {
+                  throw new Error("Authenticated regular users should not be able to read other user's data");
+                })
+                .catch(err3 => {
+                  expect(err3.code).toEqual('permission-denied');
+                  expect(err3.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+                });
+            });
+        });
+    });
+  });
+
+  test('Authenticated regular user can read his own organization', () => {
+    return clientAuth
+      .signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientAuth
+          .currentUser!.getIdTokenResult(true)
+          .then(idTokenResult => {
+            return clientDb
+              .collection('organizations')
+              .doc(idTokenResult.claims.organizationID)
+              .get()
+              .then(orgSnapshot => {
+                expect(orgSnapshot.id).toEqual(idTokenResult.claims.organizationID);
+                return orgSnapshot.data();
+              })
+              .then(org => {
+                expect(org).toBeDefined();
+                expect(org!.name).toEqual('Soylent Green');
+              })
+              .catch(err => {
+                throw err;
+              });
+          })
+          .catch(err => {
+            throw err;
+          });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test("Authenticated regular user can't read an organization he doesn't belong to", () => {
+    return clientAuth
+      .signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
         return clientDb
-          .collection('users')
-          .doc('admin@initech.com')
+          .collection('organizations')
+          .doc(initechID)
           .get()
           .then(() => {
-            throw new Error("Authenticated regular users should not be able to read other user's data");
-          })
-          .catch(err2 => {
-            expect(err2.code).toEqual('permission-denied');
-            expect(err2.message).toEqual('Missing or insufficient permissions.');
-            return clientDb
-              .collection('users')
-              .doc('user@initech.com')
-              .get()
-              .then(() => {
-                throw new Error("Authenticated regular users should not be able to read other user's data");
-              })
-              .catch(err3 => {
-                expect(err3.code).toEqual('permission-denied');
-                expect(err3.message).toEqual('Missing or insufficient permissions.');
-              });
-          });
-      });
-  });
-});
-
-test('Authenticated admin user can read his own data', () => {
-  return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
-    return clientDb
-      .collection('users')
-      .doc('admin@soylentgreen.com')
-      .get()
-      .then(userSnapshot => {
-        expect(userSnapshot.id).toEqual('admin@soylentgreen.com');
-      })
-      .catch(err => {
-        throw err;
-      });
-  });
-});
-
-test("Authenticated admin user can read other users' data if they're in his organization", () => {
-  return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
-    return clientDb
-      .collection('users')
-      .doc('user@soylentgreen.com')
-      .get()
-      .then(userSnapshot => {
-        expect(userSnapshot.id).toEqual('user@soylentgreen.com');
-      })
-      .catch(err => {
-        throw err;
-      });
-  });
-});
-
-test("Authenticated admin user can't read other users' data if they're not in his organization", () => {
-  return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
-    return clientDb
-      .collection('users')
-      .doc('admin@initech.com')
-      .get()
-      .then(userSnapshot => {
-        expect(userSnapshot.id).toEqual('user@soylentgreen.com');
-        throw new Error(
-          "Authenticated admin users should not be able to read other user's data if they're not in the same organization"
-        );
-      })
-      .catch(err => {
-        expect(err.code).toEqual('permission-denied');
-        expect(err.message).toEqual('Missing or insufficient permissions.');
-        return clientDb
-          .collection('users')
-          .doc('user@initech.com')
-          .get()
-          .then(userSnapshot => {
-            expect(userSnapshot.id).toEqual('user@soylentgreen.com');
             throw new Error(
-              "Authenticated admin users should not be able to read other user's data if they're not in the same organization"
+              "Authenticated regular user shouldn't have been able to read an organization he doesn't belong to"
             );
           })
-          .catch(err2 => {
-            expect(err2.code).toEqual('permission-denied');
-            expect(err2.message).toEqual('Missing or insufficient permissions.');
+          .catch(err => {
+            expect(err.code).toEqual('permission-denied');
+            expect(err.message).toEqual('Missing or insufficient permissions.');
           });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test("Authenticated regular user can't write his own organization", () => {
+    return clientAuth
+      .signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientAuth
+          .currentUser!.getIdTokenResult(true)
+          .then(idTokenResult => {
+            return clientDb
+              .collection('organizations')
+              .doc(idTokenResult.claims.organizationID)
+              .update({
+                newField: 'newValue'
+              })
+              .then(() => {
+                throw new Error("Authenticated regular user shouldn't be able to write to his own organization");
+              })
+              .catch(err => {
+                expect(err.code).toEqual('permission-denied');
+                expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+              });
+          })
+          .catch(err => {
+            throw err;
+          });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test("Authenticated regular user can't write an organization he doesn't belong to", () => {
+    return clientAuth
+      .signInWithEmailAndPassword('user@soylentgreen.com', 'user@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientDb
+          .collection('organizations')
+          .doc(initechID)
+          .update({
+            newField: 'newValue'
+          })
+          .then(() => {
+            throw new Error(
+              "Authenticated regular user shouldn't be able to write to an organization he doesn't belong to"
+            );
+          })
+          .catch(err => {
+            expect(err.code).toEqual('permission-denied');
+            expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+          });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+});
+
+describe('Test proper read/write permissions for admins', () => {
+  test('Authenticated admin user can read his own data', () => {
+    return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('admin@soylentgreen.com')
+        .get()
+        .then(userSnapshot => {
+          expect(userSnapshot.id).toEqual('admin@soylentgreen.com');
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+  });
+
+  test("Authenticated admin user can read other users' data if they're in his organization", () => {
+    return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('user@soylentgreen.com')
+        .get()
+        .then(userSnapshot => {
+          expect(userSnapshot.id).toEqual('user@soylentgreen.com');
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+  });
+
+  test("Authenticated admin user can't read other users' data if they're not in his organization", () => {
+    return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('admin@initech.com')
+        .get()
+        .then(() => {
+          throw new Error(
+            "Authenticated admin users should not be able to read other user's data if they're not in the same organization"
+          );
+        })
+        .catch(err => {
+          expect(err.code).toEqual('permission-denied');
+          expect(err.message).toEqual('Missing or insufficient permissions.');
+          return clientDb
+            .collection('users')
+            .doc('user@initech.com')
+            .get()
+            .then(() => {
+              throw new Error(
+                "Authenticated admin users should not be able to read other user's data if they're not in the same organization"
+              );
+            })
+            .catch(err2 => {
+              expect(err2.code).toEqual('permission-denied');
+              expect(err2.message).toEqual('Missing or insufficient permissions.');
+            });
+        });
+    });
+  });
+
+  test('Authenticated admin user can write his own data', () => {
+    return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('admin@soylentgreen.com')
+        .update({
+          newField: 'newValue'
+        })
+        .then(() => {
+          return clientDb
+            .collection('users')
+            .doc('admin@soylentgreen.com')
+            .get()
+            .then(userSnapshot => userSnapshot.data())
+            .then(user => {
+              expect(user).toBeDefined();
+              expect(user!.newField).toEqual('newValue');
+            });
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+  });
+
+  test("Authenticated admin user can write another user's data if they're in his organization", () => {
+    return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('user@soylentgreen.com')
+        .update({
+          newField: 'newValue'
+        })
+        .then(() => {
+          return clientDb
+            .collection('users')
+            .doc('user@soylentgreen.com')
+            .get()
+            .then(userSnapshot => userSnapshot.data())
+            .then(user => {
+              expect(user).toBeDefined();
+              expect(user!.newField).toEqual('newValue');
+            });
+        })
+        .catch(err => {
+          throw err;
+        });
+    });
+  });
+
+  test("Authenticated admin user can't write another user's data if they're not in his organization", () => {
+    return clientAuth.signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com').then(() => {
+      return clientDb
+        .collection('users')
+        .doc('admin@initech.com')
+        .update({
+          newField: 'newValue'
+        })
+        .then(() => {
+          throw new Error(
+            "Authenticated admin users should not be able to write other user's data if they're not in the same organization"
+          );
+        })
+        .catch(err => {
+          expect(err.code).toEqual('permission-denied');
+          expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+          return clientDb
+            .collection('users')
+            .doc('user@initech.com')
+            .update({
+              newField: 'newValue'
+            })
+            .then(() => {
+              throw new Error(
+                "Authenticated admin users should not be able to write other user's data if they're not in the same organization"
+              );
+            })
+            .catch(err2 => {
+              expect(err2.code).toEqual('permission-denied');
+              expect(err2.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+            });
+        });
+    });
+  });
+
+  test('Authenticated admin user can read his own organization', () => {
+    return clientAuth
+      .signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientAuth
+          .currentUser!.getIdTokenResult(true)
+          .then(idTokenResult => {
+            expect(idTokenResult.claims.isAdmin).toEqual(true);
+            return clientDb
+              .collection('organizations')
+              .doc(idTokenResult.claims.organizationID)
+              .get()
+              .then(orgSnapshot => {
+                expect(orgSnapshot.id).toEqual(idTokenResult.claims.organizationID);
+                return orgSnapshot.data();
+              })
+              .then(org => {
+                expect(org).toBeDefined();
+                expect(org!.name).toEqual('Soylent Green');
+              })
+              .catch(err => {
+                throw err;
+              });
+          })
+          .catch(err => {
+            throw err;
+          });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test("Authenticated admin user can't read an organization he doesn't belong to", () => {
+    return clientAuth
+      .signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientAuth
+          .currentUser!.getIdTokenResult(true)
+          .then(idTokenResult => {
+            expect(idTokenResult.claims.isAdmin).toEqual(true);
+            return clientDb
+              .collection('organizations')
+              .doc(initechID)
+              .get()
+              .then(() => {
+                throw new Error(
+                  "Authenticated admin user shouldn't have been able to read an organization he doesn't belong to"
+                );
+              })
+              .catch(err => {
+                expect(err.code).toEqual('permission-denied');
+                expect(err.message).toEqual('Missing or insufficient permissions.');
+              });
+          })
+          .catch(err => {
+            throw err;
+          });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test('Authenticated admin user can write his own organization', () => {
+    return clientAuth
+      .signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientAuth
+          .currentUser!.getIdTokenResult(true)
+          .then(idTokenResult => {
+            expect(idTokenResult.claims.isAdmin).toEqual(true);
+            return clientDb
+              .collection('organizations')
+              .doc(idTokenResult.claims.organizationID)
+              .update({
+                newField: 'newValue'
+              })
+              .then(() => {
+                return clientDb
+                  .collection('organizations')
+                  .doc(idTokenResult.claims.organizationID)
+                  .get()
+                  .then(orgSnapshot => {
+                    expect(orgSnapshot.id).toEqual(idTokenResult.claims.organizationID);
+                    return orgSnapshot.data();
+                  })
+                  .then(org => {
+                    expect(org).toBeDefined();
+                    expect(org!.newField).toEqual('newValue');
+                  })
+                  .catch(err => {
+                    throw err;
+                  });
+              })
+              .catch(err => {
+                throw err;
+              });
+          })
+          .catch(err => {
+            throw err;
+          });
+      })
+      .catch(err => {
+        throw err;
+      });
+  });
+
+  test("Authenticated admin user can't write to an organization he doesn't belong to", () => {
+    return clientAuth
+      .signInWithEmailAndPassword('admin@soylentgreen.com', 'admin@soylentgreen.com')
+      .then(() => {
+        expect(clientAuth.currentUser).toBeTruthy();
+        return clientAuth
+          .currentUser!.getIdTokenResult(true)
+          .then(idTokenResult => {
+            expect(idTokenResult.claims.isAdmin).toEqual(true);
+            return clientDb
+              .collection('organizations')
+              .doc(initechID)
+              .update({
+                newField: 'newValue'
+              })
+              .then(() => {
+                throw new Error(
+                  "Authenticated admin user shouldn't have been able to write to an organization he doesn't belong to"
+                );
+              })
+              .catch(err => {
+                expect(err.code).toEqual('permission-denied');
+                expect(err.message).toEqual('7 PERMISSION_DENIED: Missing or insufficient permissions.');
+              });
+          })
+          .catch(err => {
+            throw err;
+          });
+      })
+      .catch(err => {
+        throw err;
       });
   });
 });

--- a/cloud-functions/functions/__tests__/rules.test.ts
+++ b/cloud-functions/functions/__tests__/rules.test.ts
@@ -13,26 +13,15 @@ import 'firebase/firestore';
 jest.setTimeout(60000);
 
 // Initialize client SDK
-const firebaseConfig =
-  process.env.NODE_ENV === 'development'
-    ? {
-        apiKey: 'AIzaSyAKbS8JEe1UVSZdaJfN4RnsRFPE7Tb-YpM',
-        authDomain: 'permission-portal-dev.firebaseapp.com',
-        databaseURL: 'https://permission-portal-dev.firebaseio.com',
-        projectId: 'permission-portal-dev',
-        storageBucket: 'permission-portal-dev.appspot.com',
-        messagingSenderId: '885750041965',
-        appId: '1:885750041965:web:14133265537c686c1dde64'
-      }
-    : {
-        apiKey: 'AIzaSyAHVZXO-wFnGmUIBLxF6-mY3tuleK4ENVo',
-        authDomain: 'permission-portal-test.firebaseapp.com',
-        databaseURL: 'https://permission-portal-test.firebaseio.com',
-        projectId: 'permission-portal-test',
-        storageBucket: 'permission-portal-test.appspot.com',
-        messagingSenderId: '1090782248577',
-        appId: '1:1090782248577:web:184d481f492cfa4edc1780'
-      };
+const firebaseConfig = {
+  apiKey: 'AIzaSyAHVZXO-wFnGmUIBLxF6-mY3tuleK4ENVo',
+  authDomain: 'permission-portal-test.firebaseapp.com',
+  databaseURL: 'https://permission-portal-test.firebaseio.com',
+  projectId: 'permission-portal-test',
+  storageBucket: 'permission-portal-test.appspot.com',
+  messagingSenderId: '1090782248577',
+  appId: '1:1090782248577:web:184d481f492cfa4edc1780'
+};
 firebase.initializeApp(firebaseConfig);
 
 // Initialize admin SDK
@@ -49,10 +38,7 @@ const serviceAccount =
     : require('../../permission-portal-test-firebase-admin-key.json');
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL:
-    process.env.NODE_ENV === 'development'
-      ? 'https://permission-portal-dev.firebaseio.com'
-      : 'https://permission-portal-test.firebaseio.com'
+  databaseURL: 'https://permission-portal-test.firebaseio.com'
 });
 
 // Initialize commonly used vars

--- a/cloud-functions/functions/package.json
+++ b/cloud-functions/functions/package.json
@@ -8,7 +8,8 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "test": "NODE_ENV=test jest --forceExit"
+    "test": "NODE_ENV=test jest --forceExit",
+    "test_ci": "NODE_ENV=ci jest --forceExit"
   },
   "engines": {
     "node": "8"


### PR DESCRIPTION
Created a set of [Cloud Firestore Security Rules](https://firebase.google.com/docs/firestore/security/get-started) (`cloud-functions/firestore.rules`) that determine who can read/write to which documents in our database.

I added extensive tests in `cloud-functions/functions/__tests__/rules.test.ts` to really make sure all bases were covered. Those tests should also provide a good guide for client developers to follow for accessing data on the frontend. Again, everything prefixed by `clientDb` and `clientAuth` is from the Firestore client sdk, which we can use in the react app.