### PR TITLE
Add production environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,11 @@
 # Builds node app and deploys to AWS S3
 # 'dev' branch deploys to staging - http://permissions-staging.s3-website-us-west-1.amazonaws.com/
 
-# TO ADD AT SOME POINT: prod branch deploy to production
-
 name: Deploy
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, master]
 
 jobs:
   build:
@@ -21,7 +19,7 @@ jobs:
         with:
           node-version: "12.x"
 
-      - name: Build node app
+      - name: Build node app for staging
         working-directory: permission-portal-frontend
         env:
           CI: true
@@ -29,6 +27,17 @@ jobs:
           npm ci
           npm run init
           npm run build:staging
+        if: github.ref == 'refs/heads/dev'
+
+      - name: Build node app for prod
+        working-directory: permission-portal-frontend
+        env:
+          CI: true
+        run: |
+          npm ci
+          npm run init
+          npm run build
+        if: github.ref == 'refs/heads/master'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/permission-portal-frontend/scripts/deploy.sh
+++ b/permission-portal-frontend/scripts/deploy.sh
@@ -2,10 +2,9 @@
 
 # GITHUB_REF is the branch that triggered the action
 # It is only set when the action is triggered on a push
-if [[ ${GITHUB_REF##*/} == "prod" ]]; then
-    # Note: we don't have a prod branch set up so we should never satisfy the if statment above.  We can change the cloudfront id for prod once we have that bucket/branch
-  BUCKETNAME=permissions
-  CLOUDFRONT_INVALIDATION_ID=E2G74JWOQDFFTX
+if [[ ${GITHUB_REF##*/} == "master" ]]; then
+  BUCKETNAME=covidwatch-permissions
+  CLOUDFRONT_INVALIDATION_ID=E6HKPE76CKP
 else
   BUCKETNAME=permissions-staging
   CLOUDFRONT_INVALIDATION_ID=E2G74JWOQDFFTX
@@ -18,9 +17,9 @@ echo
 FOLDERNAME=dist
 S3_BUCKET_URI="s3://$BUCKETNAME"
 
-aws s3 cp index.html $S3_BUCKET_URI  --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z 
+aws s3 cp index.html $S3_BUCKET_URI  --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
 
-aws s3 sync $FOLDERNAME "$S3_BUCKET_URI/$FOLDERNAME" --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z
+aws s3 sync $FOLDERNAME "$S3_BUCKET_URI/$FOLDERNAME" --acl public-read --cache-control max-age=31557600,public --metadata-directive REPLACE --expires 2034-01-01T00:00:00Z --only-show-errors
 
 
 aws cloudfront create-invalidation \


### PR DESCRIPTION
Updates the deploy script and deploy workflow for the prod environment.

A push to `dev` will deploy to staging and a push to `master` will deploy to prod.

Also added the `--only-show-errors` option to the S3 commands to suppress unnecessary logging in the action.