### PR TITLE
Navbar profile img revised

### DIFF
--- a/permission-portal-cloud-functions/firestore.rules
+++ b/permission-portal-cloud-functions/firestore.rules
@@ -47,5 +47,9 @@ service cloud.firestore {
       allow read: if isSignedIn() && isInOrganization(organizationID);
       allow write: if isSignedIn() && isAdmin() && isInOrganization(organizationID);
     }
+
+    match /userImages/{email} {
+	    allow read, write: if isSignedIn() && isSelfOrAdminInOrg(email, resource.data.organizationID);
+    }
   }
 }

--- a/permission-portal-frontend/client/src/components/NavBar.js
+++ b/permission-portal-frontend/client/src/components/NavBar.js
@@ -61,7 +61,10 @@ const NavBarBase = observer((props) => {
         <div className="title">{props.store.user.isAdmin ? ROLES.ADMIN_LABEL : ROLES.NON_ADMIN_LABEL}</div>
       </div>
       <div className="avatar_group avatar_image">
-        <img src={profile} />
+        <img
+          src={props.store.user.imageBlob ? props.store.user.imageBlob : profile}
+          style={{ objectFit: 'cover', display: 'block', margin: 'auto' }}
+        ></img>
       </div>
       <div className="avatar_group separator" />
       <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="menu" onClick={handleMenu}>

--- a/permission-portal-frontend/client/src/screens/Settings.js
+++ b/permission-portal-frontend/client/src/screens/Settings.js
@@ -170,7 +170,7 @@ const SettingsBase = observer((props) => {
           Discard
         </button>
         <button onClick={saveImage} className={primaryButton.root} style={{ width: '70px', borderStyle: 'none' }}>
-          Save
+          Upload
         </button>
       </div>
     </div>

--- a/permission-portal-frontend/client/src/screens/Settings.js
+++ b/permission-portal-frontend/client/src/screens/Settings.js
@@ -138,12 +138,11 @@ const SettingsBase = observer((props) => {
         return
       }
       let reader = new FileReader()
+      // set up onload trigger to run when data is read
       reader.onload = (e) => {
-        const _state = { ...state }
-        _state.imageBlob = e.target.result
-        console.log('base64:' + _state.imageBlob)
-        setState({ ..._state })
+        props.store.user.updateImage(e.target.result)
       }
+      // read data
       reader.readAsDataURL(imgUploader.current.files[0])
     } catch (err) {
       console.log(err)
@@ -152,14 +151,16 @@ const SettingsBase = observer((props) => {
 
   const saveSettings = async (e) => {
     e.preventDefault()
-    try {
-      await props.store.user.update({ ...state })
-      console.log('user data saved successfully')
-      setToastInfo({ open: true, success: true, msg: 'Settings Saved Successfully' })
-    } catch (err) {
-      console.log(err)
-      setToastInfo({ open: true, success: false, msg: 'Failed' })
-    }
+    console.log('Deprecated, TODO: delete this functionality')
+    return
+    // try {
+    //   await props.store.user.update({ ...state })
+    //   console.log('user data saved successfully')
+    //   setToastInfo({ open: true, success: true, msg: 'Settings Saved Successfully' })
+    // } catch (err) {
+    //   console.log(err)
+    //   setToastInfo({ open: true, success: false, msg: 'Failed' })
+    // }
   }
 
   const changeImageModal = (
@@ -194,7 +195,7 @@ const SettingsBase = observer((props) => {
                 }}
               >
                 <img
-                  src={state.imageBlob ? state.imageBlob : 'client/assets/photo-add.png'}
+                  src={props.store.user.imageBlob ? props.store.user.imageBlob : 'client/assets/photo-add.png'}
                   style={{ width: '195px', height: '195px', objectFit: 'cover', display: 'block', margin: 'auto' }}
                 ></img>
               </div>

--- a/permission-portal-frontend/client/src/screens/Settings.js
+++ b/permission-portal-frontend/client/src/screens/Settings.js
@@ -149,20 +149,6 @@ const SettingsBase = observer((props) => {
     }
   }
 
-  const saveSettings = async (e) => {
-    e.preventDefault()
-    console.log('Deprecated, TODO: delete this functionality')
-    return
-    // try {
-    //   await props.store.user.update({ ...state })
-    //   console.log('user data saved successfully')
-    //   setToastInfo({ open: true, success: true, msg: 'Settings Saved Successfully' })
-    // } catch (err) {
-    //   console.log(err)
-    //   setToastInfo({ open: true, success: false, msg: 'Failed' })
-    // }
-  }
-
   const changeImageModal = (
     <div className={changeImage.root}>
       <input type="file" ref={imgUploader} accepts="image/jpeg, image/png" />
@@ -247,9 +233,6 @@ const SettingsBase = observer((props) => {
                 className={input.root}
                 defaultValue={props.store.user.email}
               ></input>
-              <button onClick={saveSettings} className={primaryButton.root}>
-                Save Changes
-              </button>
             </Grid>
           </Grid>
 

--- a/permission-portal-frontend/client/src/store/index.js
+++ b/permission-portal-frontend/client/src/store/index.js
@@ -9,7 +9,7 @@ import * as firebaseConfigDev from '../config/firebase.config.dev'
 import * as firebaseConfigTest from '../config/firebase.config.test'
 import * as firebaseConfigProd from '../config/firebase.config.prod'
 import * as firebaseConfigStaging from '../config/firebase.config.staging'
-import { types, cast, flow } from 'mobx-state-tree'
+import { types, cast, flow, isArrayType, isMapType } from 'mobx-state-tree'
 
 var firebaseConfigMap = {
   development: firebaseConfigDev,
@@ -38,7 +38,7 @@ const User = types
     isSuperAdmin: types.boolean,
     disabled: types.boolean,
     prefix: types.maybe(types.string),
-    imageBlob: types.maybe(types.string),
+    imageBlob: types.maybeNull(types.string),
     firstName: types.string,
     lastName: types.string,
     organizationID: types.string,
@@ -53,7 +53,8 @@ const User = types
     }
     const update = flow(function* (updates) {
       try {
-        yield db.collection('users').doc(self.email).update(updates)
+        const sanitized = updates //sanitize(updates)
+        yield db.collection('users').doc(self.email).set(sanitized, { merge: true })
       } catch (err) {
         console.error('Error updating users', err)
       }

--- a/permission-portal-frontend/client/src/store/index.js
+++ b/permission-portal-frontend/client/src/store/index.js
@@ -53,13 +53,21 @@ const User = types
     }
     const update = flow(function* (updates) {
       try {
-        yield db.collection('users').doc(self.email).set(updates, { merge: true })
+        yield db.collection('users').doc(self.email).update(updates)
       } catch (err) {
         console.error('Error updating users', err)
       }
     })
+    const updateImage = flow(function* (blob) {
+      try {
+        // .set() with { merge: true } so that if the document dne, it's created, otherwise its updated
+        yield db.collection('userImages').doc(self.email).set({ blob: blob }, { merge: true })
+      } catch (err) {
+        console.error('Error updating image', err)
+      }
+    })
 
-    return { __update, update }
+    return { __update, update, updateImage }
   })
 
 const Organization = types
@@ -160,6 +168,7 @@ const defaultUser = {
   firstName: '',
   lastName: '',
   organizationID: '',
+  imageBlob: null,
 }
 
 const defaultOrganization = {
@@ -196,6 +205,7 @@ const createStore = (WrappedComponent) => {
     constructor(props) {
       super(props)
       this.userDocumentListener = null
+      this.userImageListener = null
       this.organizationDocumentListener = null
       this.organizationMembersListener = null
       this.authStateListener = auth.onAuthStateChanged(async (user) => {
@@ -219,6 +229,24 @@ const createStore = (WrappedComponent) => {
                 })
               })
           }
+
+          const userImageDocumentSnapshot = await db.collection('userImages').doc(user.email).get()
+          if (userImageDocumentSnapshot.exists) {
+            console.warn(userImageDocumentSnapshot)
+            rootStore.user.__update({
+              imageBlob: userImageDocumentSnapshot.data().blob,
+            })
+          }
+          this.userImageListener = db
+            .collection('userImages')
+            .doc(user.email)
+            .onSnapshot((updatedUserImageDocumentSnapshot) => {
+              if (updatedUserImageDocumentSnapshot.exists) {
+                rootStore.user.__update({
+                  imageBlob: updatedUserImageDocumentSnapshot.data().blob,
+                })
+              }
+            })
 
           const organizationID = rootStore.user.organizationID
 

--- a/permission-portal-frontend/client/src/store/index.js
+++ b/permission-portal-frontend/client/src/store/index.js
@@ -9,7 +9,7 @@ import * as firebaseConfigDev from '../config/firebase.config.dev'
 import * as firebaseConfigTest from '../config/firebase.config.test'
 import * as firebaseConfigProd from '../config/firebase.config.prod'
 import * as firebaseConfigStaging from '../config/firebase.config.staging'
-import { types, cast, flow, isArrayType, isMapType } from 'mobx-state-tree'
+import { types, cast, flow } from 'mobx-state-tree'
 
 var firebaseConfigMap = {
   development: firebaseConfigDev,
@@ -53,8 +53,7 @@ const User = types
     }
     const update = flow(function* (updates) {
       try {
-        const sanitized = updates //sanitize(updates)
-        yield db.collection('users').doc(self.email).set(sanitized, { merge: true })
+        yield db.collection('users').doc(self.email).set(updates, { merge: true })
       } catch (err) {
         console.error('Error updating users', err)
       }


### PR DESCRIPTION
- revised My Settings so that you don't need to click the "save settings" button in order to save your profile image
- added a new collection in our firestore called `userImages` so that the app isn't downloading large amounts of useless image data (which is what would happen if we stored each image blob in the user document itself)
- updated rules to allow for reading/writing of `userImages` collection
- updated the store to handle all this new logic

This is the next iteration of @prabhuinbarajan 's work in this PR (now closed): https://github.com/covid19risk/permission-portal/pull/149