### PR TITLE
Fix Mobx Error on user status change

### DIFF
--- a/permission-portal-frontend/client/src/screens/ManageTeams.js
+++ b/permission-portal-frontend/client/src/screens/ManageTeams.js
@@ -153,8 +153,6 @@ const ManageTeamsBase = observer((props) => {
                       value={!data.disabled ? 'active' : 'deactivated'}
                       onChange={(e) => {
                         props.store.updateUserByEmail(data.email, { disabled: e.target.value == 'deactivated' })
-                        data.disabled = e.target.value == 'deactivated'
-                        e.target.className = !data.disabled ? 'active' : 'inactive'
                       }}
                       aria-labelledby="status-header"
                     >


### PR DESCRIPTION
Closes #197 

The error was caused by line 156, which was directly editing the model field. We don't need that line or the line after it, because `updateUserByEmail` invokes the `organizationMembersListener` (in `store/index.js`) which updates the user model. The `select` component is reactive, so it will update the `className` automatically when the user model is updated. 

I tested by activating and deactivating my user, and everything works as expected. 