### PR TITLE
Add circular progress margin

### DIFF
--- a/permission-portal-frontend/client/Styles/components/button.scss
+++ b/permission-portal-frontend/client/Styles/components/button.scss
@@ -18,7 +18,7 @@
   }
 }
 
-.progress-container {
+#progress-container {
     display: flex;
     justify-content: center;
 }

--- a/permission-portal-frontend/client/Styles/screens/code_validations.scss
+++ b/permission-portal-frontend/client/Styles/screens/code_validations.scss
@@ -170,9 +170,3 @@
         margin-left: 26px;
     }
 }
-
-#progress-container {
-    display: flex;
-    justify-content: center;
-}
-

--- a/permission-portal-frontend/client/Styles/screens/delete_user_modal.scss
+++ b/permission-portal-frontend/client/Styles/screens/delete_user_modal.scss
@@ -66,4 +66,8 @@
     color: #F05452;
   }
 
+  #progress-container {
+      margin-top: 20px;
+  }
+
 }


### PR DESCRIPTION
Closes #198 

Added a margin to the `progress-container` id in the delete user modal to match the margin of the button. Made sure the `progress-container` id is set in `button.scss` and not `code_validations.scss` since it is not used there and we will be redoing that page soon. 

![Screen Capture_select-area_20200606220316](https://user-images.githubusercontent.com/20446774/83960782-90913f00-a841-11ea-9e05-e1e526ca1835.png)

