### PR TITLE
Reset Password (settings page)

### DIFF
--- a/frontend/client/Styles/screens/change_password_modal.scss
+++ b/frontend/client/Styles/screens/change_password_modal.scss
@@ -3,7 +3,6 @@
   height: 100%;
   max-height: 417px + 12px;
   padding: 50px;
-  padding-top: 30px;
 
   &.err-timeout {
     max-height: 564px + 8px;
@@ -41,6 +40,10 @@
     .close_btn {
         display: none;
     }
+}
+
+.reset-modal-container{
+    padding-top: 30px;
 }
 
 .change-password-form {

--- a/frontend/client/Styles/screens/change_password_modal.scss
+++ b/frontend/client/Styles/screens/change_password_modal.scss
@@ -3,13 +3,10 @@
   height: 100%;
   max-height: 417px + 12px;
   padding: 50px;
+  padding-top: 30px;
 
   &.err-timeout {
     max-height: 564px + 8px;
-  }
-
-  .close-btn {
-    display: none;
   }
 
   h2 {
@@ -27,7 +24,7 @@
   }
 
   .close-btn {
-    margin-left: 430px;
+    margin-left: 350px;
     font-size: 18px;
   }
 
@@ -38,6 +35,12 @@
   .close-btn:hover {
     cursor: pointer;
   }
+}
+
+.first-time-modal-container{
+    .close_btn {
+        display: none;
+    }
 }
 
 .change-password-form {

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -119,7 +119,9 @@ class ChangePasswordModalBase extends React.Component {
       <>
         <Modal
           hidden={!this.state.visible}
-          containerClass={`change-password-modal-container${this.state.loginTimeoutError ? ' err-timeout' : ''}`}
+          containerClass={`change-password-modal-container${
+            this.state.loginTimeoutError ? ' err-timeout' : ''
+          } first-time-modal-container`}
           isDismissible={false}
         >
           {!this.state.loginTimeoutError ? (
@@ -209,6 +211,6 @@ class ChangePasswordModalBase extends React.Component {
   }
 }
 
-const ChangePasswordModal = withStore(ChangePasswordModalBase)
+const ChangePasswordFirstTimeModal = withStore(ChangePasswordModalBase)
 
-export default ChangePasswordModal
+export default ChangePasswordFirstTimeModal

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -211,6 +211,6 @@ class ChangePasswordModalBase extends React.Component {
   }
 }
 
-const ChangePasswordFirstTimeModal = withStore(ChangePasswordModalBase)
+const ChangePasswordModal = withStore(ChangePasswordModalBase)
 
-export default ChangePasswordFirstTimeModal
+export default ChangePasswordModal

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -17,7 +17,8 @@ class ResetPasswordModalBase extends React.Component {
       passwordIsValid: false,
       successful: false,
       message: '',
-      formHasBeenEdited: false,
+      newPasswordHasBeenEdited: false,
+      currentPasswordHasBeenEdited: false,
       confirmPasswordHasBeenEdited: false,
     }
     this.onChange = this.onChange.bind(this)
@@ -33,13 +34,13 @@ class ResetPasswordModalBase extends React.Component {
     let fieldContent = event.target.value
     // Serialize updates
     this.setState((state) => {
-      let newState = {
-        formHasBeenEdited: true,
-      }
+      let newState = {}
       if (fieldName === 'current-password') {
         newState.currentPassword = fieldContent
+        newState.currentPasswordHasBeenEdited = true
       }
       if (fieldName === 'new-password') {
+        newState.newPasswordHasBeenEdited = true
         newState.password = fieldContent
         newState.passwordIsValid = newState.password && newState.password.length >= 6
         newState.passwordsMatch = newState.password === state.confirmPassword
@@ -57,12 +58,12 @@ class ResetPasswordModalBase extends React.Component {
     Logging.error(err)
     if (err.code === 'auth/wrong-password') {
       this.props.onFailure('Current password incorrect, please try again')
+      this.setState({ currentPassword: '', currentPasswordHasBeenEdited: false })
     } else if (err.code === 'auth/too-many-requests') {
       this.props.onFailure('Too many incorrect attempts. Please try again later')
     } else {
       this.props.onFailure('Failed to reset password, please try again')
     }
-    this.setState({ currentPassword: '', confirmPassword: '', password: '' })
   }
 
   onSubmit() {
@@ -107,7 +108,9 @@ class ResetPasswordModalBase extends React.Component {
             onChange={this.onChange}
           />
           <div className="validationResult">
-            {!this.state.currentPassword ? 'Current password cannot be blank' : ''}
+            {!this.state.currentPassword && this.state.currentPasswordHasBeenEdited
+              ? 'Current password cannot be blank'
+              : ''}
           </div>
           <label htmlFor="new-password">
             New password<span>*</span>
@@ -122,7 +125,7 @@ class ResetPasswordModalBase extends React.Component {
             onChange={this.onChange}
           />
           <div className="validationResult">
-            {!this.state.passwordIsValid && this.state.formHasBeenEdited
+            {!this.state.passwordIsValid && this.state.newPasswordHasBeenEdited
               ? this.state.password.length > 0
                 ? 'Password must be at least 6 characters long'
                 : 'New password cannot be blank'

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -57,12 +57,12 @@ class ResetPasswordModalBase extends React.Component {
   handleFirebaseError(err) {
     Logging.error(err)
     if (err.code === 'auth/wrong-password') {
-      this.props.onFailure('Current password incorrect, please try again')
+      this.props.onFailure('Current password incorrect. Please try again.')
       this.setState({ currentPassword: '', currentPasswordHasBeenEdited: false })
     } else if (err.code === 'auth/too-many-requests') {
-      this.props.onFailure('Too many incorrect attempts. Please try again later')
+      this.props.onFailure('Too many incorrect attempts. Please try again later.')
     } else {
-      this.props.onFailure('Failed to reset password, please try again')
+      this.props.onFailure('Failed to reset password. Please try again.')
     }
   }
 

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -6,7 +6,7 @@ import { withStore } from '../store'
 import Logging from '../util/logging'
 import firebase from 'firebase'
 
-class ChangePasswordModalBase extends React.Component {
+class ResetPasswordModalBase extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
@@ -87,7 +87,11 @@ class ChangePasswordModalBase extends React.Component {
 
   render() {
     return (
-      <Modal hidden={this.props.hidden} onClose={this.props.onClose} containerClass="change-password-modal-container">
+      <Modal
+        hidden={this.props.hidden}
+        onClose={this.props.onClose}
+        containerClass="change-password-modal-container reset-modal-container"
+      >
         <h2> Change Password </h2>
         <form className="change-password-form">
           <label htmlFor="current-password">
@@ -152,6 +156,6 @@ class ChangePasswordModalBase extends React.Component {
   }
 }
 
-const ChangePasswordModal = withStore(ChangePasswordModalBase)
+const ResetPasswordModal = withStore(ResetPasswordModalBase)
 
-export default ChangePasswordModal
+export default ResetPasswordModal

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -57,10 +57,9 @@ class ChangePasswordModalBase extends React.Component {
     Logging.error(err)
     if (err.code === 'auth/wrong-password') {
       this.props.onFailure('Current password incorrect, please try again')
-    } else if(err.code === 'auth/too-many-requests') {
-          this.props.onFailure('Too many incorrect attempts. Please try again later')
-      }
-      else {
+    } else if (err.code === 'auth/too-many-requests') {
+      this.props.onFailure('Too many incorrect attempts. Please try again later')
+    } else {
       this.props.onFailure('Failed to reset password, please try again')
     }
     this.setState({ currentPassword: '', confirmPassword: '', password: '' })

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -1,0 +1,158 @@
+import React, { createRef } from 'react'
+import Modal from '../components/Modal'
+import PendingOperationButton from '../components/PendingOperationButton'
+import { auth } from '../store/firebase'
+import { withStore } from '../store'
+import Logging from '../util/logging'
+import firebase from 'firebase'
+
+class ChangePasswordModalBase extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentPassword: '',
+      password: '',
+      confirmPassword: '',
+      passwordsMatch: true,
+      passwordIsValid: false,
+      successful: false,
+      message: '',
+      formHasBeenEdited: false,
+      confirmPasswordHasBeenEdited: false,
+    }
+    this.onChange = this.onChange.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
+    this.canSubmit = this.canSubmit.bind(this)
+    this.handleFirebaseError = this.handleFirebaseError.bind(this)
+
+    this.toast = createRef()
+  }
+
+  onChange(event) {
+    let fieldName = event.target.name
+    let fieldContent = event.target.value
+    // Serialize updates
+    this.setState((state) => {
+      let newState = {
+        formHasBeenEdited: true,
+      }
+      if (fieldName === 'current-password') {
+        newState.currentPassword = fieldContent
+      }
+      if (fieldName === 'new-password') {
+        newState.password = fieldContent
+        newState.passwordIsValid = newState.password && newState.password.length >= 6
+        newState.passwordsMatch = newState.password === state.confirmPassword
+      }
+      if (fieldName === 'confirm-password') {
+        newState.confirmPasswordHasBeenEdited = true
+        newState.confirmPassword = fieldContent
+        newState.passwordsMatch = state.password === newState.confirmPassword
+      }
+      return newState
+    })
+  }
+
+  handleFirebaseError(err) {
+    Logging.error(err)
+    if (err.code === 'auth/wrong-password') {
+      this.props.onFailure('Current password incorrect, please try again')
+    } else if(err.code === 'auth/too-many-requests') {
+          this.props.onFailure('Too many incorrect attempts. Please try again later')
+      }
+      else {
+      this.props.onFailure('Failed to reset password, please try again')
+    }
+    this.setState({ currentPassword: '', confirmPassword: '', password: '' })
+  }
+
+  onSubmit() {
+    const user = auth.currentUser
+    const credential = firebase.auth.EmailAuthProvider.credential(user.email, this.state.currentPassword)
+    user
+      .reauthenticateWithCredential(credential)
+      .then(() => {
+        user
+          .updatePassword(this.state.password)
+          .then(this.props.onSuccess())
+          .catch((e) => this.handleFirebaseError(e))
+      })
+      .catch((e) => {
+        this.handleFirebaseError(e)
+      })
+  }
+
+  canSubmit() {
+    return this.state.currentPassword && this.state.passwordIsValid && this.state.passwordsMatch
+  }
+
+  render() {
+    return (
+      <Modal hidden={this.props.hidden} onClose={this.props.onClose} containerClass="change-password-modal-container">
+        <h2> Change Password </h2>
+        <form className="change-password-form">
+          <label htmlFor="current-password">
+            Current password<span>*</span>
+          </label>
+          <input
+            type="password"
+            required
+            aria-required={true}
+            id="current-password"
+            name="current-password"
+            value={this.state.currentPassword}
+            onChange={this.onChange}
+          />
+          <div className="validationResult">
+            {!this.state.currentPassword ? 'Current password cannot be blank' : ''}
+          </div>
+          <label htmlFor="new-password">
+            New password<span>*</span>
+          </label>
+          <input
+            type="password"
+            required
+            aria-required={true}
+            id="new-password"
+            name="new-password"
+            value={this.state.password}
+            onChange={this.onChange}
+          />
+          <div className="validationResult">
+            {!this.state.passwordIsValid && this.state.formHasBeenEdited
+              ? this.state.password.length > 0
+                ? 'Password must be at least 6 characters long'
+                : 'New password cannot be blank'
+              : ''}
+          </div>
+          <label htmlFor="confirm-password">
+            Confirm new password<span>*</span>
+          </label>
+          <input
+            type="password"
+            required
+            aria-required={true}
+            id="confirm-password"
+            name="confirm-password"
+            value={this.state.confirmPassword}
+            onChange={this.onChange}
+          />
+          <div className="validationResult">
+            {!this.state.passwordsMatch && this.state.confirmPasswordHasBeenEdited ? 'Passwords must match' : ''}
+          </div>
+
+          <PendingOperationButton
+            className={`save-password${this.canSubmit() ? '' : '-disabled'}`}
+            operation={this.onSubmit}
+          >
+            Change Password
+          </PendingOperationButton>
+        </form>
+      </Modal>
+    )
+  }
+}
+
+const ChangePasswordModal = withStore(ChangePasswordModalBase)
+
+export default ChangePasswordModal

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -11,6 +11,7 @@ import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import photo_add from '../../assets/photo-add.svg'
 import Logging from '../util/logging'
+import ResetPasswordModal from '../components/ResetPasswordModal'
 import ChangePasswordModal from '../components/ChangePasswordModal'
 
 const useStyles = makeStyles({
@@ -93,31 +94,19 @@ const SettingsBase = observer((props) => {
   const secondaryButton = secondaryButtonStyles()
   const primaryButton = primaryButtonStyles()
   const changeImage = changeImageModalStyles()
-  const [open, setOpen] = useState(false)
+  const [showChangeImageModal, setShowChangeImageModal] = useState(false)
+  const [showChangePasswordModal, setShowChangePasswordModal] = useState(false)
   const [toastInfo, setToastInfo] = useState({
     success: false,
     msg: '',
   })
   const toastRef = useRef()
 
-  const handleOpen = () => {
-    setOpen(true)
-  }
-  const handleClose = () => {
-    setOpen(false)
-  }
   const resetPassword = async (e) => {
     e.preventDefault()
-    try {
-      await props.store.sendPasswordResetEmail(props.store.data.user.email)
-      setToastInfo({ success: true, msg: `Password Reset Email Sent to ${props.store.data.user.email}` })
-      toastRef.current.show()
-    } catch (err) {
-      Logging.error(err)
-      setToastInfo({ success: false, msg: 'Password Reset Failed. Please try again' })
-      toastRef.current.show()
-    }
+    setShowChangePasswordModal(true)
   }
+
   const onChange = async (event) => {
     if (event.target.name == 'prefix') {
       props.store.updateUser({ prefix: event.target.value })
@@ -130,7 +119,7 @@ const SettingsBase = observer((props) => {
 
   const saveImage = async (e) => {
     e.preventDefault()
-    setOpen(false)
+    setShowChangeImageModal(false)
     if (imgUploader.current.files.length == 0) {
       Logging.log('no image uploaded')
       return
@@ -160,11 +149,36 @@ const SettingsBase = observer((props) => {
     }
   }
 
+  const onChangePasswordSuccess = () => {
+    setToastInfo({
+      success: true,
+      msg: 'Password Succesfully Reset',
+    })
+    toastRef.current.show()
+    setShowChangePasswordModal(false)
+  }
+
+  const onChangePasswordFailure = (message) => {
+    setToastInfo({
+      success: false,
+      msg: message,
+    })
+    toastRef.current.show()
+  }
+
+  const onChangePasswordClose = () => {
+    setShowChangePasswordModal(false)
+  }
+
   const changeImageModal = (
     <div className={changeImage.root}>
       <input type="file" ref={imgUploader} accepts="image/jpeg, image/png" />
       <div style={{ alignContent: 'right', marginTop: '35px' }}>
-        <button onClick={handleClose} className={secondaryButton.root} style={{ width: '100px', border: 'none' }}>
+        <button
+          onClick={() => setShowChangeImageModal(false)}
+          className={secondaryButton.root}
+          style={{ width: '100px', border: 'none' }}
+        >
           Discard
         </button>
         <button onClick={saveImage} className={primaryButton.root} style={{ width: '70px', borderStyle: 'none' }}>
@@ -201,10 +215,10 @@ const SettingsBase = observer((props) => {
                 Accepted file types: jpg or png
               </div>
               <div style={{ fontSize: '12px', fontWeight: 'normal', color: '#585858' }}>Maximum file size: 10 MB</div>
-              <button onClick={handleOpen} type="button" className={secondaryButton.root}>
+              <button onClick={() => setShowChangeImageModal(true)} type="button" className={secondaryButton.root}>
                 Change Image
               </button>
-              <Modal open={open} onClose={handleClose}>
+              <Modal open={showChangeImageModal} onClose={() => setShowChangeImageModal(false)}>
                 {changeImageModal}
               </Modal>
             </Grid>
@@ -324,6 +338,12 @@ const SettingsBase = observer((props) => {
         <p>Changes are automatically saved</p>
       </div>
       {settingsForm()}
+      <ResetPasswordModal
+        hidden={!showChangePasswordModal}
+        onClose={onChangePasswordClose}
+        onSuccess={onChangePasswordSuccess}
+        onFailure={onChangePasswordFailure}
+      />
       <ChangePasswordModal />
     </React.Fragment>
   ) : (

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -95,7 +95,7 @@ const SettingsBase = observer((props) => {
   const primaryButton = primaryButtonStyles()
   const changeImage = changeImageModalStyles()
   const [showChangeImageModal, setShowChangeImageModal] = useState(false)
-  const [showChangePasswordModal, setShowChangePasswordModal] = useState(false)
+  const [showResetPasswordModal, setShowResetPasswordModal] = useState(false)
   const [toastInfo, setToastInfo] = useState({
     success: false,
     msg: '',
@@ -104,7 +104,7 @@ const SettingsBase = observer((props) => {
 
   const resetPassword = async (e) => {
     e.preventDefault()
-    setShowChangePasswordModal(true)
+    setShowResetPasswordModal(true)
   }
 
   const onChange = async (event) => {
@@ -155,7 +155,7 @@ const SettingsBase = observer((props) => {
       msg: 'Password Succesfully Reset',
     })
     toastRef.current.show()
-    setShowChangePasswordModal(false)
+    setShowResetPasswordModal(false)
   }
 
   const onChangePasswordFailure = (message) => {
@@ -167,7 +167,7 @@ const SettingsBase = observer((props) => {
   }
 
   const onChangePasswordClose = () => {
-    setShowChangePasswordModal(false)
+    setShowResetPasswordModal(false)
   }
 
   const changeImageModal = (
@@ -339,7 +339,7 @@ const SettingsBase = observer((props) => {
       </div>
       {settingsForm()}
       <ResetPasswordModal
-        hidden={!showChangePasswordModal}
+        hidden={!showResetPasswordModal}
         onClose={onChangePasswordClose}
         onSuccess={onChangePasswordSuccess}
         onFailure={onChangePasswordFailure}


### PR DESCRIPTION
Closes #244 

Adds `ResetPasswordModal` which is very similar to `ChangePasswordModal` (thanks @aidan-fitz !). After #243 is finished, we can abstract out what is the same between the 3 modals into a common base component. 

### Note
Changes to the `change image modal` component in `Settings` will be overrideen by #246, I just changed them here to avoid errors. 