### PR TITLE
Unify buttons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Code Style Guide
+
+**Buttons:** Use the `PendingOperationButton` component whenever a button triggers an action that is 
+asynchronous and may take some time, such as updating data in the store or on the server. 
+`PendingOperationButton`'s `operation` property accepts a function that takes no arguments and 
+returns a `Promise` (or is `async`; they're equivalent). For actions that complete immediately, such 
+as opening or closing a modal, use a naked `<button>` element.

--- a/frontend/client/Styles/screens/change_password_modal.scss
+++ b/frontend/client/Styles/screens/change_password_modal.scss
@@ -67,7 +67,7 @@
     color: #585858;
     margin-top: 11px;
   }
-  .save-password, .save-password-disabled {
+  .save-password {
     width: 350px;
     height: 50px;
     border-radius: 7px;
@@ -81,19 +81,9 @@
     display: flex;
     justify-content: center;
     align-items: center;
-  }
 
-  .save-password {
-    color: white;
-    background: #2C58B1;
-    border: 15px;
-    cursor: pointer;
-  }
-
-  .save-password-disabled {
-    color: #BDBDBD;
-    background: white;
-    border: 2px solid #BDBDBD;
-    pointer-events: none;
+    &.disabled {
+      border: 2px solid #BDBDBD;
+    }
   }
 }

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -195,10 +195,7 @@ class ChangePasswordModalBase extends React.Component {
               {!this.state.passwordsMatch && this.state.confirmPasswordHasBeenEdited ? 'Passwords must match' : ''}
             </div>
 
-            <PendingOperationButton
-              className={`save-password${this.canSubmit() ? '' : '-disabled'}`}
-              operation={this.onSubmit}
-            >
+            <PendingOperationButton className="save-password" disabled={!this.canSubmit()} operation={this.onSubmit}>
               {!this.state.loginTimeoutError ? 'Save' : 'Retry'}
             </PendingOperationButton>
           </form>

--- a/frontend/client/src/components/ForgotPasswordModal.js
+++ b/frontend/client/src/components/ForgotPasswordModal.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Modal from '../components/Modal'
 import { withStore } from '../store'
+import PendingOperationButton from './PendingOperationButton'
 
 class ForgotPasswordModal extends React.Component {
   constructor(props) {
@@ -11,15 +12,12 @@ class ForgotPasswordModal extends React.Component {
     this.handleChange = this.handleChange.bind(this)
   }
 
-  async onSubmit(event) {
-    event.preventDefault()
-
+  async onSubmit() {
     if (!this.state.email) {
       this.setState({ validEmail: false })
-      return
+      throw new Error()
     }
-
-    const isSuccess = await this.props.store.sendPasswordResetEmail(this.state.email)
+    const isSuccess = this.props.store.sendPasswordResetEmail(this.state.email)
     this.setState({ isSuccess: isSuccess, emailPrompt: false, email: '', validEmail: true })
   }
 
@@ -40,10 +38,9 @@ class ForgotPasswordModal extends React.Component {
           <form onSubmit={this.onSubmit} onChange={this.handleChange}>
             <label htmlFor="email-or-username">Email or User Name</label>
             <input type="text" id="email-or-username" required />
-            <button type="submit" className="save-button recovery-button">
-              {' '}
-              Email Recovery Link{' '}
-            </button>
+            <PendingOperationButton operation={this.onSubmit} className="save-button recovery-button">
+              Email Recovery Link
+            </PendingOperationButton>
             {!this.state.validEmail && <div className="validationResult">Please enter an email or user name.</div>}
           </form>
         </Modal>

--- a/frontend/client/src/components/PendingOperationButton.js
+++ b/frontend/client/src/components/PendingOperationButton.js
@@ -1,15 +1,24 @@
 import React from 'react'
 import CircularProgress from '@material-ui/core/CircularProgress'
 
-// Encapsulates a button driven operation which takes time and may succeed or fail
+/**
+ * Encapsulates a button driven operation which takes time and may succeed or fail.
+ *
+ * Props:
+ *  - operation: Should return a Promise.
+ *  - className: Any additional styles to apply to this component instance. button and disabled
+ *    are applied by default.
+ *  - disabled: false by default.
+ */
 const PendingOperationButton = (props) => {
   const [state, setState] = React.useState({
     isOperationStarted: false,
     operationSucceeded: false,
   })
 
-  const className = props.className || ''
+  const className = (props.className || '') + ' button' + (props.disabled ? ' disabled' : '')
   const operation = props.operation || (() => {})
+  const disabled = props.disabled || false
 
   const startOperation = () => {
     setState({
@@ -41,9 +50,9 @@ const PendingOperationButton = (props) => {
 
   if (!state.isOperationStarted) {
     return (
-      <div className={className} onClick={startOperation}>
+      <button className={className} disabled={disabled} onClick={startOperation}>
         {props.children}
-      </div>
+      </button>
     )
   } else {
     return (

--- a/frontend/client/src/components/PendingOperationButton.js
+++ b/frontend/client/src/components/PendingOperationButton.js
@@ -5,7 +5,7 @@ import CircularProgress from '@material-ui/core/CircularProgress'
  * Encapsulates a button driven operation which takes time and may succeed or fail.
  *
  * Props:
- *  - operation: Should return a Promise.
+ *  - operation: Should return a Promise or be an async function.
  *  - className: Any additional styles to apply to this component instance. button and disabled
  *    are applied by default.
  *  - disabled: false by default.

--- a/frontend/client/src/components/PendingOperationButton.js
+++ b/frontend/client/src/components/PendingOperationButton.js
@@ -17,6 +17,7 @@ const PendingOperationButton = (props) => {
   })
 
   const className = (props.className || '') + ' button' + (props.disabled ? ' disabled' : '')
+  const style = props.style || {}
   const operation = props.operation || (() => {})
   const disabled = props.disabled || false
 
@@ -50,7 +51,7 @@ const PendingOperationButton = (props) => {
 
   if (!state.isOperationStarted) {
     return (
-      <button className={className} disabled={disabled} onClick={startOperation}>
+      <button className={className} disabled={disabled} style={style} onClick={startOperation}>
         {props.children}
       </button>
     )

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -30,16 +30,13 @@ const SignInFormBase = observer(
       this.errorToast = createRef()
     }
 
-    clickSubmit = () => {
-      return new Promise(() => {
-        const { email, password } = this.state
-        try {
-          this.props.store.signInWithEmailAndPassword(email, password)
-        } catch (err) {
-          this.errorToast.current.show()
-          throw err
-        }
-      })
+    clickSubmit = async () => {
+      const { email, password } = this.state
+      try {
+        await this.props.store.signInWithEmailAndPassword(email, password)
+      } catch (err) {
+        this.errorToast.current.show()
+      }
     }
 
     onChange = (name) => (event) => {

--- a/frontend/client/src/screens/Login.js
+++ b/frontend/client/src/screens/Login.js
@@ -10,6 +10,7 @@ import { observer } from 'mobx-react'
 import ForgotPasswordModal from '../components/ForgotPasswordModal'
 import PageTitle from '../components/PageTitle'
 import Toast from '../components/Toast'
+import PendingOperationButton from '../components/PendingOperationButton'
 
 const INITIAL_STATE = {
   email: '',
@@ -29,14 +30,16 @@ const SignInFormBase = observer(
       this.errorToast = createRef()
     }
 
-    clickSubmit = async (event) => {
-      event.preventDefault()
-      const { email, password } = this.state
-      try {
-        await this.props.store.signInWithEmailAndPassword(email, password)
-      } catch (err) {
-        this.errorToast.current.show()
-      }
+    clickSubmit = () => {
+      return new Promise(() => {
+        const { email, password } = this.state
+        try {
+          this.props.store.signInWithEmailAndPassword(email, password)
+        } catch (err) {
+          this.errorToast.current.show()
+          throw err
+        }
+      })
     }
 
     onChange = (name) => (event) => {
@@ -83,7 +86,7 @@ const SignInFormBase = observer(
             <input onChange={this.onChange('email')} type="email" id="email" name="email" />
             <label htmlFor="password">Password</label>
             <input onChange={this.onChange('password')} type="password" id="password" name="password" />
-            <button onClick={this.clickSubmit}>Login</button>
+            <PendingOperationButton operation={this.clickSubmit}>Login</PendingOperationButton>
             <a onClick={this.showModal}>Forgot password?</a>
           </div>
           <ForgotPasswordModal hidden={!this.state.showPassModal} onClose={this.hideModal} />

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -12,6 +12,7 @@ import PageTitle from '../components/PageTitle'
 import photo_add from '../../assets/photo-add.svg'
 import Logging from '../util/logging'
 import ChangePasswordModal from '../components/ChangePasswordModal'
+import PendingOperationButton from '../components/PendingOperationButton'
 
 const useStyles = makeStyles({
   root: {
@@ -167,9 +168,13 @@ const SettingsBase = observer((props) => {
         <button onClick={handleClose} className={secondaryButton.root} style={{ width: '100px', border: 'none' }}>
           Discard
         </button>
-        <button onClick={saveImage} className={primaryButton.root} style={{ width: '70px', borderStyle: 'none' }}>
+        <PendingOperationButton
+          operation={saveImage}
+          className={primaryButton.root}
+          style={{ width: '96px', borderStyle: 'none' }}
+        >
           Upload
-        </button>
+        </PendingOperationButton>
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #109.

- Use `PendingOperationButton` whenever we need an `async` function, naked `<button>` elements otherwise. Note: `operation` prop must be an `async` function or return `Promise` (both are equivalent in JavaScript).
- Add `disabled` and `style` props to POB.
- Convert POB to use a `<button>` tag internally and have `button` and `disabled` CSS classes by default. This simplifies CSS a bit, but we still need to refactor the CSS to use fewer custom classes.