### PR TITLE
Disable no-console only in logging.js

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -18,7 +18,6 @@ module.exports = {
   rules: {
     'prettier/prettier': 'error',
     'react/prop-types': 0,
-    'no-console': 0,
   },
   settings: {
     react: {

--- a/frontend/client/src/util/logging.js
+++ b/frontend/client/src/util/logging.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 const Logging = {
   log: console.log,
   warn: console.warn,


### PR DESCRIPTION
Removes the rule `no-console: 0` except in `logging.js`.

Closes #122