### PR TITLE
Fix disabled user Firebase test

### DIFF
--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -438,6 +438,7 @@ test('User can be toggled between enabled and disabled', () => {
       });
     })
     .catch(async (err) => {
+      // Revert to previous state if the test fails
       await adminDb
         .collection('users')
         .doc('disabled@soylentgreen.com')

--- a/cloud-functions/functions/__tests__/auth.test.ts
+++ b/cloud-functions/functions/__tests__/auth.test.ts
@@ -437,7 +437,13 @@ test('User can be toggled between enabled and disabled', () => {
         });
       });
     })
-    .catch((err) => {
+    .catch(async (err) => {
+      await adminDb
+        .collection('users')
+        .doc('disabled@soylentgreen.com')
+        .update({
+          disabled: true,
+        })
       throw err;
     });
 });


### PR DESCRIPTION
If the test fails, revert the user object's `disabled` property back to `true`.

See #265