### PR TITLE
Use object-fit: cover

### DIFF
--- a/frontend/client/Styles/application.scss
+++ b/frontend/client/Styles/application.scss
@@ -8,6 +8,7 @@
 @import 'components/toast';
 @import 'components/button';
 @import 'components/modal';
+@import 'components/profile_photo';
 
 .hidden {
   display: none;

--- a/frontend/client/Styles/components/profile_photo.scss
+++ b/frontend/client/Styles/components/profile_photo.scss
@@ -1,0 +1,5 @@
+.profile_photo {
+  object-fit: cover;
+  display: block;
+  margin: auto;
+}

--- a/frontend/client/src/components/NavBar.js
+++ b/frontend/client/src/components/NavBar.js
@@ -63,7 +63,7 @@ const NavBarBase = observer((props) => {
       <div className="avatar_group avatar_image">
         <img
           src={props.store.data.user.imageBlob ? props.store.data.user.imageBlob : profile}
-          style={{ objectFit: 'cover', display: 'block', margin: 'auto' }}
+          className="profile_photo"
           alt=""
         ></img>
       </div>

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -188,7 +188,7 @@ const SettingsBase = observer((props) => {
                 <img
                   alt={props.store.data.user.imageBlob ? 'Profile photo' : 'Your profile photo would go here.'}
                   src={props.store.data.user.imageBlob ? props.store.data.user.imageBlob : photo_add}
-                  style={{ width: '212px', height: '217px', objectFit: 'none', display: 'block', margin: 'auto' }}
+                  style={{ width: '212px', height: '217px', objectFit: 'cover', display: 'block', margin: 'auto' }}
                 ></img>
               </div>
               <div style={{ marginTop: '15px', fontSize: '12px', fontWeight: 'normal', color: '#585858' }}>

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -188,7 +188,8 @@ const SettingsBase = observer((props) => {
                 <img
                   alt={props.store.data.user.imageBlob ? 'Profile photo' : 'Your profile photo would go here.'}
                   src={props.store.data.user.imageBlob ? props.store.data.user.imageBlob : photo_add}
-                  style={{ width: '212px', height: '217px', objectFit: 'cover', display: 'block', margin: 'auto' }}
+                  className="profile_photo"
+                  style={{ width: '212px', height: '217px' }}
                 ></img>
               </div>
               <div style={{ marginTop: '15px', fontSize: '12px', fontWeight: 'normal', color: '#585858' }}>


### PR DESCRIPTION
Fixes #285.

Changing the profile pic CSS from `object-fit: none` to `object-fit: cover` resizes the image to fill its parent element.
![Screenshot from 2020-06-23 17-54-22](https://user-images.githubusercontent.com/2768977/85468922-0a803280-b57b-11ea-9474-dfc9adf93361.png)
