### PR TITLE
Refactor route blocking

### DIFF
--- a/frontend/client/src/screens/404.js
+++ b/frontend/client/src/screens/404.js
@@ -6,7 +6,6 @@ import '../../Styles/screens/404.scss'
 import PageTitle from '../components/PageTitle'
 import ucsf_health from '../../assets/ucsf-health.svg'
 import powered_by_cw from '../../assets/powered-by-cw.svg'
-import ChangePasswordModal from '../components/ChangePasswordModal'
 
 const NotFound = () => {
   return (
@@ -36,7 +35,6 @@ const NotFound = () => {
           <img src={FemaleDoctor} alt="doctor" />
         </div>
       </div>
-      <ChangePasswordModal />
     </div>
   )
 }

--- a/frontend/client/src/screens/AccountBranding.js
+++ b/frontend/client/src/screens/AccountBranding.js
@@ -7,7 +7,6 @@ import * as ROUTES from '../constants/routes'
 import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import Logging from '../util/logging'
-import ChangePasswordModal from '../components/ChangePasswordModal'
 
 const AccountBrandingBase = observer((props) => {
   const [isSuccess, setIsSuccess] = useState(false)
@@ -189,7 +188,6 @@ const AccountBrandingBase = observer((props) => {
         isSuccess={isSuccess}
         message={isSuccess ? 'Branding saved successfully' : 'Failed to save branding'}
       />
-      <ChangePasswordModal />
     </div>
   )
 })

--- a/frontend/client/src/screens/AccountBranding.js
+++ b/frontend/client/src/screens/AccountBranding.js
@@ -84,7 +84,12 @@ const AccountBrandingBase = observer((props) => {
     setExposureTextIsEditing(false)
   }
 
-  return props.store.data.user.isSignedIn && props.store.data.user.isAdmin ? (
+  return !props.store.data.user.isSignedIn ||
+    !props.store.data.user.isAdmin ||
+    props.store.data.user.isFirstTimeUser ||
+    (props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) ? (
+    <Redirect to={ROUTES.LANDING} />
+  ) : (
     <div className="module-container module-container-branding">
       <PageTitle title="Account Branding" />
       <h1 className="branding-header">Account Branding</h1>
@@ -186,10 +191,6 @@ const AccountBrandingBase = observer((props) => {
       />
       <ChangePasswordModal />
     </div>
-  ) : props.store.data.user.isSignedIn ? (
-    <Redirect to={ROUTES.CODE_VALIDATIONS} />
-  ) : (
-    <Redirect to={ROUTES.LANDING} />
   )
 })
 

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -7,7 +7,6 @@ import { Redirect } from 'react-router-dom'
 import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import PendingOperationButton from '../components/PendingOperationButton'
-import ChangePasswordModal from '../components/ChangePasswordModal'
 
 // snackbars docs can be found here:
 // https://material-ui.com/components/snackbars/
@@ -56,7 +55,6 @@ const CodeValidationsBase = observer((props) => {
         </div>
       </div>
       <Toast ref={confirmedToast} isSuccess={toastInfo.success} message={toastInfo.msg} />
-      <ChangePasswordModal />
     </div>
   )
 })

--- a/frontend/client/src/screens/CodeValidations.js
+++ b/frontend/client/src/screens/CodeValidations.js
@@ -33,7 +33,11 @@ const CodeValidationsBase = observer((props) => {
     }
   }
 
-  return props.store.data.user.isSignedIn ? (
+  return !props.store.data.user.isSignedIn ||
+    props.store.data.user.isFirstTimeUser ||
+    (props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) ? (
+    <Redirect to={ROUTES.LANDING} />
+  ) : (
     <div className="module-container">
       <PageTitle title="Positive Test Validations" />
       <h1>Positive Test Validations</h1>
@@ -54,8 +58,6 @@ const CodeValidationsBase = observer((props) => {
       <Toast ref={confirmedToast} isSuccess={toastInfo.success} message={toastInfo.msg} />
       <ChangePasswordModal />
     </div>
-  ) : (
-    <Redirect to={ROUTES.LANDING} />
   )
 })
 

--- a/frontend/client/src/screens/ManageTeams.js
+++ b/frontend/client/src/screens/ManageTeams.js
@@ -71,7 +71,12 @@ const ManageTeamsBase = observer((props) => {
     }
   }
 
-  return props.store.data.user.isSignedIn && props.store.data.user.isAdmin ? (
+  return !props.store.data.user.isSignedIn ||
+    !props.store.data.user.isAdmin ||
+    props.store.data.user.isFirstTimeUser ||
+    (props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) ? (
+    <Redirect to={ROUTES.LANDING} />
+  ) : (
     <div className="module-container">
       <PageTitle title="Manage Members" />
       <h1>Manage Members</h1>
@@ -161,10 +166,6 @@ const ManageTeamsBase = observer((props) => {
       <Toast ref={confirmationToast} isSuccess={isSuccess} message={toastMessage} />
       <ChangePasswordModal />
     </div>
-  ) : props.store.data.user.isSignedIn ? (
-    <Redirect to={ROUTES.CODE_VALIDATIONS} />
-  ) : (
-    <Redirect to={ROUTES.LANDING} />
   )
 })
 

--- a/frontend/client/src/screens/ManageTeams.js
+++ b/frontend/client/src/screens/ManageTeams.js
@@ -13,7 +13,6 @@ import { withStore } from '../store'
 import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import Logging from '../util/logging'
-import ChangePasswordModal from '../components/ChangePasswordModal'
 
 const ManageTeamsBase = observer((props) => {
   const userEmail = props.store.data.user.email
@@ -164,7 +163,6 @@ const ManageTeamsBase = observer((props) => {
         </div>
       </div>
       <Toast ref={confirmationToast} isSuccess={isSuccess} message={toastMessage} />
-      <ChangePasswordModal />
     </div>
   )
 })

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -316,7 +316,11 @@ const SettingsBase = observer((props) => {
     </Fragment>
   )
 
-  return props.store.data.user.isSignedIn ? (
+  return !props.store.data.user.isSignedIn ||
+    props.store.data.user.isFirstTimeUser ||
+    (props.store.data.user.passwordResetRequested && props.store.data.user.signedInWithEmailLink) ? (
+    <Redirect to={ROUTES.LANDING} />
+  ) : (
     <React.Fragment>
       <PageTitle title="My Settings" />
       <div className="module-container">
@@ -334,8 +338,6 @@ const SettingsBase = observer((props) => {
         />
       </div>
     </React.Fragment>
-  ) : (
-    <Redirect to={ROUTES.LANDING} />
   )
 })
 

--- a/frontend/client/src/screens/Settings.js
+++ b/frontend/client/src/screens/Settings.js
@@ -13,7 +13,6 @@ import photo_add from '../../assets/photo-add.svg'
 import Logging from '../util/logging'
 import PendingOperationButton from '../components/PendingOperationButton'
 import ResetPasswordModal from '../components/ResetPasswordModal'
-import ChangePasswordModal from '../components/ChangePasswordModal'
 
 const useStyles = makeStyles({
   root: {
@@ -329,7 +328,6 @@ const SettingsBase = observer((props) => {
           <p>Changes are automatically saved</p>
         </div>
         {settingsForm()}
-        <ChangePasswordModal />
         <ResetPasswordModal
           hidden={!showResetPasswordModal}
           onClose={onChangePasswordClose}


### PR DESCRIPTION
Refactored route blocking to be more consistent, and to account for isFirstTimeUser and passwordResetRequested && signedInWithEmailLink.

(I spent a bunch of time tinkering around in search for a more elegant solution consisting of composed higher order components (similar to `withStore`), but gave up when I started bumping into weird ES versioning issues with babel.)

closes https://github.com/covid19risk/permission-portal/issues/275