### PR TITLE
Create bespoke ChangeRoleModal

### DIFF
--- a/frontend/client/Styles/application.scss
+++ b/frontend/client/Styles/application.scss
@@ -3,6 +3,7 @@
 @import 'screens/add_member_modal';
 @import 'screens/forgot_password_modal';
 @import 'screens/change_password_modal';
+@import 'screens/change_role_modal';
 @import 'components/footer';
 @import 'components/navbar';
 @import 'components/toast';

--- a/frontend/client/Styles/components/modal.scss
+++ b/frontend/client/Styles/components/modal.scss
@@ -18,4 +18,9 @@
     background-color: white;
     z-index: 1;
     border: 2px solid #BDBDBD;
+
+    .close-btn:hover {
+      cursor: pointer;
+    }
 }
+

--- a/frontend/client/Styles/screens/change_role_modal.scss
+++ b/frontend/client/Styles/screens/change_role_modal.scss
@@ -1,0 +1,29 @@
+.change-role-modal-container {
+  width: 360px;
+  min-height: 300px;
+  padding: 25px 27px 44px 49px;
+
+  h2 {
+    margin-top: 0px;
+    margin-bottom: 35px;
+    font-weight: 600;
+    font-family: Montserrat;
+    font-size: 28px;
+  }
+
+  p {
+    color: #585858;
+    font-size: 16px;
+    line-height: 20px;
+    margin-right: 15px;
+  }
+
+  b {
+    font-weight: 600;
+  }
+
+  .close-btn {
+    margin-left: 330px;
+    font-size: 18px;
+  }
+}

--- a/frontend/client/Styles/screens/change_role_modal.scss
+++ b/frontend/client/Styles/screens/change_role_modal.scss
@@ -19,6 +19,10 @@
     margin-bottom: 14px;
   }
 
+  .role-change {
+    margin-left: 1em;
+  }
+
   b {
     font-weight: 600;
   }

--- a/frontend/client/Styles/screens/change_role_modal.scss
+++ b/frontend/client/Styles/screens/change_role_modal.scss
@@ -33,6 +33,11 @@
     height: 50px;
     font-size: 18px;
     line-height: 22px;
+
+  }
+  
+  .button:hover {
+    cursor: pointer;
   }
 
   .cancel {

--- a/frontend/client/Styles/screens/change_role_modal.scss
+++ b/frontend/client/Styles/screens/change_role_modal.scss
@@ -16,6 +16,7 @@
     font-size: 16px;
     line-height: 20px;
     margin-right: 15px;
+    margin-bottom: 14px;
   }
 
   b {

--- a/frontend/client/Styles/screens/change_role_modal.scss
+++ b/frontend/client/Styles/screens/change_role_modal.scss
@@ -26,4 +26,22 @@
     margin-left: 330px;
     font-size: 18px;
   }
+
+  .button {
+    width: 165px;
+    height: 50px;
+    font-size: 18px;
+    line-height: 22px;
+  }
+
+  .cancel {
+    background-color: white;
+    color: #2C58B1;
+    border: 2px solid #2C58B1;
+    margin-right: 21px;
+  }
+
+  .confirm {
+    border: 2px solid #2C58B1;
+  }
 }

--- a/frontend/client/src/components/ChangePasswordModal.js
+++ b/frontend/client/src/components/ChangePasswordModal.js
@@ -99,7 +99,7 @@ class ChangePasswordModalBase extends React.Component {
       <>
         <Modal
           hidden={!this.state.visible}
-          containerClass={`change-password-modal-container`}
+          containerClass="change-password-modal-container"
           isDismissible={this.state.isDismissible}
           onClose={this.onClose}
         >

--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -21,12 +21,10 @@ const ChangeRoleModalBase = (props) => {
       <p>
         Please confirm that you would like to change the role of <b>{fullName}</b>.
       </p>
-      <p>
-        From <b>{fromRole}</b>
-      </p>
-
-      <p>
-        To <b>{toRole}</b>
+      <p className="role-change">
+        From: <b>{fromRole}</b>
+        <br />
+        To: <b>{toRole}</b>
       </p>
       <p>{fullName} will recieve an email notification once this change is confirmed.</p>
 

--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -23,8 +23,12 @@ const ChangeRoleModalBase = (props) => {
         {fullName} will recieve an email notification once this change is confirmed.
       </p>
 
-      <button onClick={props.onClose}>Cancel</button>
-      <PendingOperationButton operation={onConfirm}>Confirm</PendingOperationButton>
+      <button className="button cancel" onClick={props.onClose}>
+        Cancel
+      </button>
+      <PendingOperationButton className="confirm" operation={onConfirm}>
+        Confirm
+      </PendingOperationButton>
     </Modal>
   )
 }

--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -19,7 +19,16 @@ const ChangeRoleModalBase = (props) => {
       <h2>Confirm Change</h2>
 
       <p>
-        Please confirm that you would like to change the role of {fullName} from <b>{fromRole}</b> to <b>{toRole}</b>.{' '}
+        Please confirm that you would like to change the role of <b>{fullName}</b>. 
+      </p>
+      <p>
+        From <b>{fromRole}</b>  
+      </p>
+
+      <p>
+        To <b>{toRole}</b>
+      </p>
+      <p>
         {fullName} will recieve an email notification once this change is confirmed.
       </p>
 

--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -15,12 +15,12 @@ const ChangeRoleModalBase = (props) => {
   }
 
   return (
-    <Modal hidden={props.hidden} onClose={props.onClose}>
+    <Modal hidden={props.hidden} onClose={props.onClose} containerClass="change-role-modal-container">
       <h2>Confirm Change</h2>
 
       <p>
-        Please confirm that you would like to change the role of {fullName} from
-        {fromRole} to {toRole}. {fullName} will recieve an email notification once this change is confirmed.
+        Please confirm that you would like to change the role of {fullName} from <b>{fromRole}</b> to <b>{toRole}</b>.{' '}
+        {fullName} will recieve an email notification once this change is confirmed.
       </p>
 
       <button onClick={props.onClose}>Cancel</button>

--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import Modal from '../components/Modal'
+import { withStore } from '../store'
+import * as ROLES from '../constants/roles'
+import PendingOperationButton from './PendingOperationButton'
+
+const ChangeRoleModalBase = (props) => {
+  const fullName = `${props.userProperties.firstName} ${props.userProperties.lastName}`
+  const fromRole = props.userProperties.isAdmin ? ROLES.ADMIN_LABEL : ROLES.NON_ADMIN_LABEL
+  const toRole = props.userProperties.isAdmin ? ROLES.NON_ADMIN_LABEL : ROLES.ADMIN_LABEL
+
+  const onConfirm = async () => {
+    props.store.updateUserByEmail(props.userProperties.email, { isAdmin: !props.userProperties.isAdmin })
+    props.onClose()
+  }
+
+  return (
+    <Modal hidden={props.hidden} onClose={props.onClose}>
+      <h2>Confirm Change</h2>
+
+      <p>
+        Please confirm that you would like to change the role of {fullName} from
+        {fromRole} to {toRole}. {fullName} will recieve an email notification once this change is confirmed.
+      </p>
+
+      <button onClick={props.onClose}>Cancel</button>
+      <PendingOperationButton operation={onConfirm}>Confirm</PendingOperationButton>
+    </Modal>
+  )
+}
+
+const ChangeRoleModal = withStore(ChangeRoleModalBase)
+
+export default ChangeRoleModal

--- a/frontend/client/src/components/ChangeRoleModal.js
+++ b/frontend/client/src/components/ChangeRoleModal.js
@@ -19,23 +19,21 @@ const ChangeRoleModalBase = (props) => {
       <h2>Confirm Change</h2>
 
       <p>
-        Please confirm that you would like to change the role of <b>{fullName}</b>. 
+        Please confirm that you would like to change the role of <b>{fullName}</b>.
       </p>
       <p>
-        From <b>{fromRole}</b>  
+        From <b>{fromRole}</b>
       </p>
 
       <p>
         To <b>{toRole}</b>
       </p>
-      <p>
-        {fullName} will recieve an email notification once this change is confirmed.
-      </p>
+      <p>{fullName} will recieve an email notification once this change is confirmed.</p>
 
       <button className="button cancel" onClick={props.onClose}>
         Cancel
       </button>
-      <PendingOperationButton className="confirm" operation={onConfirm}>
+      <PendingOperationButton className="button confirm" operation={onConfirm}>
         Confirm
       </PendingOperationButton>
     </Modal>

--- a/frontend/client/src/screens/ManageTeams.js
+++ b/frontend/client/src/screens/ManageTeams.js
@@ -8,11 +8,11 @@ import '../../Styles/screens/manage_teams.scss'
 import AddMemberModal from '../components/AddMemberModal'
 import Toast from '../components/Toast'
 import RoleSelector from '../components/RoleSelector'
-import * as ROLES from '../constants/roles'
 import { withStore, PAGE_SIZE } from '../store'
 import { observer } from 'mobx-react'
 import PageTitle from '../components/PageTitle'
 import Logging from '../util/logging'
+import ChangeRoleModal from '../components/ChangeRoleModal'
 
 const ManageTeamsBase = observer((props) => {
   const userEmail = props.store.data.user.email
@@ -23,6 +23,8 @@ const ManageTeamsBase = observer((props) => {
   const confirmationToast = useRef()
 
   const [showAddMemberModal, setShowAddMemberModal] = useState(false)
+  const [showChangeRoleModal, setShowChangeRoleModal] = useState(false)
+  const [changeRoleModalUserProperties, setChangeRoleModalUserProperties] = useState({})
 
   const onAddMemberCancel = () => {
     setShowAddMemberModal(false)
@@ -44,15 +46,17 @@ const ManageTeamsBase = observer((props) => {
   }
 
   const handleRoleChange = (e, isAdmin, firstName, lastName, email) => {
-    if (
-      confirm(
-        `Are you sure you want swicth ${firstName} ${lastName} from ${
-          isAdmin ? ROLES.ADMIN_LABEL : ROLES.NON_ADMIN_LABEL
-        } to ${isAdmin ? ROLES.NON_ADMIN_LABEL : ROLES.ADMIN_LABEL}`
-      )
-    ) {
-      props.store.updateUserByEmail(email, { isAdmin: e.target.value == ROLES.ADMIN_LABEL })
-    }
+    setChangeRoleModalUserProperties({
+      isAdmin,
+      firstName,
+      lastName,
+      email,
+    })
+    setShowChangeRoleModal(true)
+  }
+
+  const onChangeRoleModalClose = () => {
+    setShowChangeRoleModal(false)
   }
 
   const resetPassword = async (e, email) => {
@@ -88,6 +92,11 @@ const ManageTeamsBase = observer((props) => {
         onClose={onAddMemberCancel}
         onSuccess={onAddMemberSuccess}
         onFailure={onAddMemberFailure}
+      />
+      <ChangeRoleModal
+        hidden={!showChangeRoleModal}
+        onClose={onChangeRoleModalClose}
+        userProperties={changeRoleModalUserProperties}
       />
       <table>
         <thead>


### PR DESCRIPTION
Closes #273

`ChangeRoleModal` looks like:
![you can tell I've watched too much Avatar recently](https://user-images.githubusercontent.com/2768977/85792417-75f40c80-b701-11ea-92be-d43994e27840.png)

To test: toggle a user's role between Org Admin and Validator to bring up the prompt, then click Confirm to ensure the role is changed or Cancel to exit.