### PR TITLE
Modify Add Member modal to fit on smaller screens

### DIFF
--- a/frontend/client/Styles/screens/add_member_modal.scss
+++ b/frontend/client/Styles/screens/add_member_modal.scss
@@ -4,6 +4,10 @@
   max-height: 634px;
   padding: 20px;
 
+  @media screen and (max-height: 634px) {
+    overflow: scroll;
+  }
+
   h1 {
     margin-left: 48px;
     margin-bottom: 10px;

--- a/frontend/client/Styles/screens/change_password_modal.scss
+++ b/frontend/client/Styles/screens/change_password_modal.scss
@@ -35,23 +35,23 @@
   }
 }
 
-.reset-modal-container{
-    padding-top: 30px;
+.reset-modal-container {
+  padding-top: 30px;
 }
 
 .change-password-form {
   .validationResult {
-    color: #F05452;
+    color: #f05452;
     font-size: smaller;
     min-height: 16px;
   }
   span {
-    color: #F05452;
+    color: #f05452;
   }
   input {
     width: 350px;
     height: 50px;
-    border: 2px solid #BDBDBD;
+    border: 2px solid #bdbdbd;
     box-shadow: inset 0px 2px 10px rgba(0, 0, 0, 0.1);
     border-radius: 7px;
     font-family: 'Montserrat', sans-serif;
@@ -80,9 +80,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-bottom: 20px;
 
     &.disabled {
-      border: 2px solid #BDBDBD;
+      border: 2px solid #bdbdbd;
     }
   }
 }

--- a/frontend/client/src/components/AddMemberModal.js
+++ b/frontend/client/src/components/AddMemberModal.js
@@ -118,7 +118,7 @@ const AddMemberModalBase = observer((props) => {
           onChange={handleChange}
         />
         {state.firstNameValidationFailed && <div className="validationResult">{state.firstNameValidationMessage}</div>}
-        <label htmlFor="lastName">
+        <label htmlFor="lastName" style={{ marginTop: state.firstNameValidationFailed ? '6px' : null }}>
           Last Name<span>*</span>
         </label>
         <input
@@ -131,7 +131,7 @@ const AddMemberModalBase = observer((props) => {
           onChange={handleChange}
         />
         {state.lastNameValidationFailed && <div className="validationResult">{state.lastNameValidationMessage}</div>}
-        <label htmlFor="email">
+        <label htmlFor="email" style={{ marginTop: state.lastNameValidationFailed ? '6px' : null }}>
           Email<span>*</span>
         </label>
         <input
@@ -144,7 +144,7 @@ const AddMemberModalBase = observer((props) => {
           onChange={handleChange}
         />
         {state.emailValidationFailed && <div className="validationResult">{state.emailValidationMessage}</div>}
-        <label htmlFor="role">
+        <label htmlFor="role" style={{ marginTop: state.emailValidationFailed ? '6px' : null }}>
           Role<span>*</span>
         </label>
         <RoleSelector isAdmin={false} id="role" required={true} onChange={handleChange} />

--- a/frontend/client/src/components/ResetPasswordModal.js
+++ b/frontend/client/src/components/ResetPasswordModal.js
@@ -147,10 +147,7 @@ class ResetPasswordModalBase extends React.Component {
             {!this.state.passwordsMatch && this.state.confirmPasswordHasBeenEdited ? 'Passwords must match' : ''}
           </div>
 
-          <PendingOperationButton
-            className={`save-password${this.canSubmit() ? '' : '-disabled'}`}
-            operation={this.onSubmit}
-          >
+          <PendingOperationButton className={`save-password`} disabled={!this.canSubmit()} operation={this.onSubmit}>
             Change Password
           </PendingOperationButton>
         </form>


### PR DESCRIPTION
Previously, on failure, add member modal looked whacko on small screens:
<img width="503" alt="Screen Shot 2020-06-25 at 3 26 38 PM" src="https://user-images.githubusercontent.com/13578537/85798383-3671f400-b6f2-11ea-9423-2a7e7250e19a.png">

Fixed that by adding some inline styling logic.

closes https://github.com/covid19risk/permission-portal/issues/188